### PR TITLE
fix: add required pathes to excluded AuthMiddleware pipeline

### DIFF
--- a/backend/src/modules/app/app.module.ts
+++ b/backend/src/modules/app/app.module.ts
@@ -77,10 +77,28 @@ export class AppModule implements NestModule {
         { path: "auth/test-login", method: RequestMethod.POST },
         { path: "auth/get-fresh-token", method: RequestMethod.POST },
         { path: "auth/endpoints", method: RequestMethod.GET },
+
         // Health checks and public endpoints
         { path: "health", method: RequestMethod.GET },
         { path: "", method: RequestMethod.GET }, // Root endpoint
-        { path: "storage", method: RequestMethod.GET }, // Public storage endpoint
+
+        // Public storage and item endpoints (for front page)
+        { path: "storage", method: RequestMethod.GET },
+        { path: "storage-items", method: RequestMethod.GET },
+        { path: "storage-items/(.*)", method: RequestMethod.GET }, // For specific item endpoints
+        { path: "api/storage-locations", method: RequestMethod.GET },
+        { path: "storage-locations", method: RequestMethod.GET },
+        { path: "storage-locations/(.*)", method: RequestMethod.GET },
+
+        // Public tag endpoints
+        { path: "tags", method: RequestMethod.GET },
+        { path: "tags/(.*)", method: RequestMethod.GET },
+
+        // Public item images endpoints
+        { path: "item-images/(.*)", method: RequestMethod.GET },
+
+        // Public booking availability endpoints (for checking item availability)
+        { path: "bookings/availability/(.*)", method: RequestMethod.GET },
       )
       .forRoutes(
         // Protected controllers


### PR DESCRIPTION
Fix an issue, when any GET request to:

        { path: "storage", method: RequestMethod.GET },
        { path: "storage-items", method: RequestMethod.GET },
        { path: "api/storage-locations", method: RequestMethod.GET },
        { path: "storage-locations", method: RequestMethod.GET },
        { path: "tags/(.*)", method: RequestMethod.GET },
        { path: "item-images/(.*)", method: RequestMethod.GET },
        { path: "bookings/availability/(.*)", method: RequestMethod.GET },

required a JWT. A guest user couldn't get items with tags and other stuff.