### PR TITLE
Con2 111 get rid of no unsafe assignment rule in config

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -26,10 +26,18 @@ export default tseslint.config(
     },
   },
   {
-    rules: {
-      "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-floating-promises": "warn",
+    rules: {      // -------- “any”‑related safety nets --------
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-function-type": "off",
+      "@typescript-eslint/no-unsafe-type-assertion": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      // -------- Promise‑related safety nets --------
+      "@typescript-eslint/no-floating-promises": "warn",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "prettier/prettier": [
         "error",

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -30,6 +30,7 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-floating-promises": "warn",
       "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
       "prettier/prettier": [
         "error",
         {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -48,7 +48,7 @@ export default tseslint.config(
 
       // -------- Promise‑related safety nets --------
       "@typescript-eslint/no-misused-promises": "off",
-      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/no-floating-promises": "warn",
       "@typescript-eslint/await-thenable": "off",
 
       /* Still surface *explicit* `any` usage so devs notice it, but don't block

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,18 +8,54 @@ import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended"
 export default tseslint.config(
   { ignores: ["dist", "node_module", "src/types/supabase.types.ts", "build"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+    ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
     },
+    // Put our rules here
     rules: {
+      /* React‑specific lint rules */
       ...reactHooks.configs.recommended.rules,
+
+      // ────────────────  CON2‑111: TEMPORARY “unsafe” overrides  ────────────────
+      /* These rules shout whenever an `any` value leaks through async flows,
+         Redux slices, Supabase payloads, etc.  We disable them for now so the
+         pipeline stays green while we migrate to strict typing.  Re‑enable one
+         block at a time. */
+
+      // -------- “any”‑related safety nets --------
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-function-type": "off",
+      "@typescript-eslint/no-unsafe-type-assertion": "off",
+
+      // -------- Promise‑related safety nets --------
+      "@typescript-eslint/no-misused-promises": "off",
+      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/await-thenable": "off",
+
+      /* Still surface *explicit* `any` usage so devs notice it, but don't block
+         CI while we work through the backlog. */
+      "@typescript-eslint/no-explicit-any": "warn",
+
+      // ---------- React Fast Refresh ----------
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/frontend/src/api/test.ts
+++ b/frontend/src/api/test.ts
@@ -1,0 +1,5 @@
+// lint-test.ts
+const raw: any = { id: 123 }; // <-- `any`
+const user: { id: number } = raw; // unsafe assignment when the rule is ON
+
+user.id = 2;

--- a/frontend/src/api/test.ts
+++ b/frontend/src/api/test.ts
@@ -1,5 +1,0 @@
-// lint-test.ts
-const raw: any = { id: 123 }; // <-- `any`
-const user: { id: number } = raw; // unsafe assignment when the rule is ON
-
-user.id = 2;


### PR DESCRIPTION
This pull request updates ESLint configurations for both the backend and frontend projects, focusing on temporary overrides for TypeScript safety rules and stricter type-checking. The changes aim to maintain pipeline stability during the transition to stricter typing while surfacing potential issues for future resolution.

### Backend ESLint Configuration Updates:
* Disabled several TypeScript safety rules related to unsafe operations, such as `@typescript-eslint/no-unsafe-assignment` and `@typescript-eslint/no-unsafe-call`, while retaining warnings for explicit `any` usage. This provides flexibility during the migration to stricter typing. (`backend/eslint.config.mjs`, [backend/eslint.config.mjsL29-R41](diffhunk://#diff-91cf0077970e95faf88f9d6465a633fb0946398900f9b64fef8995779d198273L29-R41))

### Frontend ESLint Configuration Updates:
* Added `tseslint.configs.recommendedTypeChecked` to enforce stricter type-checking for TypeScript files. (`frontend/eslint.config.js`, [frontend/eslint.config.jsL11-R58](diffhunk://#diff-8b60be22f06ef19ea3a74fcfb99817cadbc339930dcb44aeeb7ee968098f447dL11-R58))
* Introduced temporary overrides for TypeScript safety rules, similar to the backend, to suppress errors related to unsafe operations. These rules are flagged for later re-enablement as part of the migration plan. (`frontend/eslint.config.js`, [frontend/eslint.config.jsL11-R58](diffhunk://#diff-8b60be22f06ef19ea3a74fcfb99817cadbc339930dcb44aeeb7ee968098f447dL11-R58))
* Configured `parserOptions` to enable project-aware linting with `tsconfigRootDir` and `projectService`. (`frontend/eslint.config.js`, [frontend/eslint.config.jsL11-R58](diffhunk://#diff-8b60be22f06ef19ea3a74fcfb99817cadbc339930dcb44aeeb7ee968098f447dL11-R58))