### PR TITLE
allow users to change their profile info including addresses

### DIFF
--- a/backend/src/guards/roles.guard.ts
+++ b/backend/src/guards/roles.guard.ts
@@ -71,6 +71,20 @@ export class RolesGuard implements CanActivate {
     // Optional super_admin bypass
     if (userRoles.some((r) => r.role_name === "super_admin")) return true;
 
+    //Allow "user" role to access/modify their own user resource
+    if (
+      userRoles.some((r) => r.role_name === "user") &&
+      req.user &&
+      req.params &&
+      req.params.id &&
+      req.user.id === req.params.id
+    ) {
+      // Only allow if the required role is "user"
+      if (required.includes("user")) {
+        return true;
+      }
+    }
+
     // Determine organisation context when sameOrg flag is set
     const orgCtx =
       sameOrg &&

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -64,7 +64,9 @@ export class UserController {
   }
 
   @Put(":id")
-  @Roles(["admin", "super_admin", "superVera", "main_admin"], { match: "any" })
+  @Roles(["user", "admin", "super_admin", "superVera", "main_admin"], {
+    match: "any",
+  })
   async updateUser(
     @Param("id") id: string,
     @Body() user: Partial<CreateUserDto>,
@@ -89,7 +91,9 @@ export class UserController {
   // Address Endpoints
 
   @Get(":id/addresses")
-  @Roles(["admin", "super_admin", "superVera", "main_admin"], { match: "any" })
+  @Roles(["user", "admin", "super_admin", "superVera", "main_admin"], {
+    match: "any",
+  })
   async getAddresses(
     @Param("id") id: string,
     @Req() req: AuthRequest,
@@ -100,7 +104,9 @@ export class UserController {
   }
 
   @Post(":id/addresses")
-  @Roles(["admin", "super_admin", "main_admin", "superVera"], { match: "any" })
+  @Roles(["user", "admin", "super_admin", "main_admin", "superVera"], {
+    match: "any",
+  })
   async addAddress(
     @Param("id") id: string,
     @Body() address: CreateAddressDto,
@@ -110,7 +116,9 @@ export class UserController {
   }
 
   @Put(":id/addresses/:addressId")
-  @Roles(["admin", "super_admin", "superVera"], { match: "any" })
+  @Roles(["user", "admin", "super_admin", "main_admin", "superVera"], {
+    match: "any",
+  })
   async updateAddress(
     @Param("id") id: string,
     @Param("addressId") addressId: string,
@@ -121,7 +129,9 @@ export class UserController {
   }
 
   @Delete(":id/addresses/:addressId")
-  @Roles(["admin", "super_admin", "superVera"], { match: "any" })
+  @Roles(["user", "admin", "super_admin", "main_admin", "superVera"], {
+    match: "any",
+  })
   async deleteAddress(
     @Param("id") id: string,
     @Param("addressId") addressId: string,

--- a/frontend/src/store/slices/rolesSlice.ts
+++ b/frontend/src/store/slices/rolesSlice.ts
@@ -379,6 +379,8 @@ export const selectIsAdmin = (state: RootState) => {
   return (
     hasRole(state, "admin") ||
     hasRole(state, "superVera") ||
+    hasRole(state, "main_admin") ||
+    hasRole(state, "super_admin") ||
     state.roles.isSuperVera
   );
 };


### PR DESCRIPTION
Allow the user role to edit their own data at the following endpoints:

- users/:id
- users/:id/addresses — although this one might be excessive.

Also selectIsAdmin(rolesSlice) accepts all admin roles from the list: admin, main_admin, superVera, super_admin (think about requester and storage_manager later)