### PR TITLE
Con2 124 admin refresh bug

### DIFF
--- a/frontend/src/components/Admin/AdminPanel.tsx
+++ b/frontend/src/components/Admin/AdminPanel.tsx
@@ -19,11 +19,8 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
-//import { useAppSelector } from "@/store/hooks";
-//import { selectIsSuperVera } from "@/store/slices/usersSlice";
 
 const AdminPanel = () => {
-  //const isSuperVera = useAppSelector(selectIsSuperVera);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   // Translation
   const { lang } = useLanguage();

--- a/frontend/src/components/Auth/AuthRedirect.tsx
+++ b/frontend/src/components/Auth/AuthRedirect.tsx
@@ -1,26 +1,54 @@
 import { useAuth } from "@/hooks/useAuth";
 import { useRoles } from "@/hooks/useRoles";
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useRef } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export const AuthRedirect = () => {
   const { user } = useAuth();
-  const { hasRole, isAdmin, isSuperVera } = useRoles();
+  const {
+    hasRole,
+    isAdmin,
+    isSuperAdmin,
+    isSuperVera,
+    loading: rolesLoading,
+  } = useRoles();
   const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTriggered = useRef(false);
 
   useEffect(() => {
-    if (user) {
-      // Check if user has admin privileges (admin role or superVera)
-      if (isAdmin || isSuperVera) {
+    // Only redirect if:
+    // 1. User and roles are loaded
+    // 2. We're on the login page or root page (suggesting fresh login)
+    // 3. Haven't already triggered a redirect
+    if (
+      user &&
+      !rolesLoading &&
+      !redirectTriggered.current &&
+      (location.pathname === "/login" || location.pathname === "/")
+    ) {
+      redirectTriggered.current = true;
+
+      // Check if user has admin privileges
+      if (isAdmin || isSuperAdmin || isSuperVera) {
         void navigate("/admin"); // redirect to Admin Panel for admin users
-      } else if (hasRole("user")) {
-        void navigate("/"); // redirect to Landing Page for regular users
+      } else if (hasRole("user") || hasRole("requester")) {
+        void navigate("/storage"); // redirect to Storage Page for regular users
       } else {
-        // Fallback: if no specific role found, redirect to landing page
-        void navigate("/");
+        // Fallback: if no specific role found, redirect to storage page
+        void navigate("/storage");
       }
     }
-  }, [user, hasRole, isAdmin, isSuperVera, navigate]);
+  }, [
+    user,
+    rolesLoading,
+    hasRole,
+    isAdmin,
+    isSuperAdmin,
+    isSuperVera,
+    navigate,
+    location.pathname,
+  ]);
 
   return null;
 };

--- a/frontend/src/components/Auth/ProtectedRoute.tsx
+++ b/frontend/src/components/Auth/ProtectedRoute.tsx
@@ -20,16 +20,24 @@ const ProtectedRoute = ({
   allowedRoles = [],
   requiredOrganization,
 }: ProtectedRouteProps) => {
-  const { authLoading } = useAuth(); // wait for supabase auth to finish
+  const { authLoading, user } = useAuth(); // wait for supabase auth to finish
   const { loading: rolesLoading, hasAnyRole, isSuperVera } = useRoles(); // roles from the new schema
 
   // Use a state variable to track if access check has been performed
   const [accessChecked, setAccessChecked] = useState(false);
   const [hasAccess, setHasAccess] = useState(false);
 
+  // Reset access check when loading states change
   useEffect(() => {
-    // Only perform the check once when data is loaded
-    if (!authLoading && !rolesLoading && !accessChecked) {
+    if (authLoading || rolesLoading) {
+      setAccessChecked(false);
+      setHasAccess(false);
+    }
+  }, [authLoading, rolesLoading]);
+
+  useEffect(() => {
+    // Only perform the check once when data is loaded AND user is authenticated
+    if (!authLoading && !rolesLoading && !accessChecked && user) {
       // NEW SYSTEM: Check if user has role in JWT-based roles across all organizations
       const hasNewRole = hasAnyRole(allowedRoles, requiredOrganization);
 
@@ -47,6 +55,7 @@ const ProtectedRoute = ({
     isSuperVera,
     requiredOrganization,
     accessChecked,
+    user,
   ]);
 
   // Show loading state while authentication or checking is in progress

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -7,6 +7,7 @@ import { AuthContext } from "./AuthContext";
 import { useAppDispatch } from "@/store/hooks";
 import { resetRoles } from "@/store/slices/rolesSlice";
 import { clearSelectedUser } from "@/store/slices/usersSlice";
+import { AuthRedirect } from "@/components/Auth/AuthRedirect";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
@@ -99,7 +100,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           <LoaderCircle className="animate-spin w-6 h-6" />
         </div>
       ) : (
-        children
+        <>
+          {user && <AuthRedirect />}
+          {children}
+        </>
       )}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
### Issues addressed in this bugfix:

- Access Denied Bug: Admin users were getting "Access Denied" errors when refreshing admin pages
- Redirect Issue: users weren't being automatically redirected to appropriate pages after login

### Improvements to Authentication and Role Handling:

* [`frontend/src/components/Auth/AuthRedirect.tsx`](diffhunk://#diff-389f29dd0896d7ba3f7af4ddd8b08bf973812080aafe80427f6841267b1c961dL3-R51): Enhanced the redirection logic to include a `useRef` to prevent repeated redirects and added checks for a new role (`isSuperAdmin`). Updated the fallback behavior to redirect users without specific roles to the storage page instead of the landing page.

* [`frontend/src/components/Auth/ProtectedRoute.tsx`](diffhunk://#diff-7debb2028c2abde1a2b11d2c0a9751577578d9907a05a6e73d0d300332ddd038L23-R40): Improved access control by resetting the access check state when authentication or role-loading states change. Added a condition to ensure access checks are only performed when the user is authenticated. [[1]](diffhunk://#diff-7debb2028c2abde1a2b11d2c0a9751577578d9907a05a6e73d0d300332ddd038L23-R40) [[2]](diffhunk://#diff-7debb2028c2abde1a2b11d2c0a9751577578d9907a05a6e73d0d300332ddd038R58)

### Integration of `AuthRedirect` Component:

* [`frontend/src/context/AuthProvider.tsx`](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5R10): Integrated the `AuthRedirect` component into the `AuthProvider` (it was not used before) to handle user redirection based on roles immediately after authentication. This ensures consistent redirection logic across the application. [[1]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5R10) [[2]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5L102-R106)

### Code Cleanup:

* [`frontend/src/components/Admin/AdminPanel.tsx`](diffhunk://#diff-b68c880c1e3e7893dd1f31f336efab59057236141493d9dfe9f9be8e9606bd8dL22-L26): Removed unused imports and commented-out code related to role selection, simplifying the `AdminPanel` component.

### Things to note:
Since we are using `useRole()` hook now also in the authentication, we get EXCESSIVE API calls in /admin pages (many components are calling the hook simultaneously, each triggering separate API calls). To improve the performance issue, I suggest applying a time-limited caching into the hook itself maybe? Also we could set the skipInitialFetch: false in some admin components? We should discuss this in our meeting and with Martin, if needed.