### PR TITLE
add translations to org locations and update admin panel with hasRole

### DIFF
--- a/frontend/src/components/Admin/AdminPanel.tsx
+++ b/frontend/src/components/Admin/AdminPanel.tsx
@@ -24,7 +24,7 @@ const AdminPanel = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   // Translation
   const { lang } = useLanguage();
-  const { isSuperAdmin, hasAnyRole } = useRoles();
+  const { hasAnyRole, hasRole } = useRoles();
   const canManageLocations = hasAnyRole([
     "main_admin",
     "storage_manager",
@@ -44,12 +44,15 @@ const AdminPanel = () => {
             end={true}
             dataCy="admin-nav-dashboard"
           />
-          {isSuperAdmin && (
+          {hasRole("super_admin") && (
             <SidebarLink
               to="/admin/organizations"
               icon={<Building2 className="w-5 h-5" />}
-              label={t.adminPanel.navigation.organizations[lang]}
+              label={
+                t.adminPanel.navigation.organizations[lang] || "Organizations"
+              }
               end={true}
+              dataCy="admin-nav-organizations"
             />
           )}
 
@@ -81,13 +84,6 @@ const AdminPanel = () => {
             dataCy="admin-nav-users"
           />
 
-          {/* {isSuperVera && (
-            <SidebarLink
-              to="/admin/team"
-              icon={<Users className="w-5 h-5"/>}
-              label={t.adminPanel.navigation.team[lang]}
-            />
-          )} */}
           <SidebarLink
             to="/admin/logs"
             icon={<FileText className="w-5 h-5" />}
@@ -103,22 +99,12 @@ const AdminPanel = () => {
             dataCy="admin-nav-roles"
           />
 
-          {/* Add the new Organizations link */}
-          <SidebarLink
-            to="/admin/organizations"
-            icon={<Building2 className="w-5 h-5" />}
-            label={
-              t.adminPanel.navigation.organizations?.[lang] || "Organizations"
-            }
-            dataCy="admin-nav-organizations"
-          />
-
           {/* Organization Locations - accessible to storage managers and above */}
           {canManageLocations && (
             <SidebarLink
               to="/admin/locations"
               icon={<MapPin className="w-5 h-5" />}
-              label="Locations"
+              label={t.adminPanel.navigation.locations[lang]}
               dataCy="admin-nav-locations"
             />
           )}
@@ -173,13 +159,6 @@ const AdminPanel = () => {
               icon={<Users />}
               label={t.adminPanel.navigation.users[lang]}
             />
-            {/* {isSuperVera && (
-              <SidebarLink 
-                to="/admin/team" 
-                icon={<Users />} 
-                label={t.adminPanel.navigation.team[lang]} 
-              />
-            )} */}
             <SidebarLink
               to="/admin/logs"
               icon={<FileText />}

--- a/frontend/src/components/Admin/OrgManagement/AddLocationModal.tsx
+++ b/frontend/src/components/Admin/OrgManagement/AddLocationModal.tsx
@@ -19,6 +19,8 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { CreateOrgLocationWithStorage } from "@/types/organizationLocation";
 import { toast } from "sonner";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
 
 interface AddLocationModalProps {
   organizationId: string;
@@ -44,6 +46,7 @@ const AddLocationModal = ({
   onClose,
 }: AddLocationModalProps) => {
   const dispatch = useAppDispatch();
+  const { lang } = useLanguage();
   const [formData, setFormData] = useState<StorageLocationFormData>({
     name: "",
     street: "",
@@ -66,7 +69,7 @@ const AddLocationModal = ({
       !formData.city.trim() ||
       !formData.postcode.trim()
     ) {
-      toast.error("Name, street, city, and postcode are required");
+      toast.error(t.orgLocationManagement.validation.requiredFields[lang]);
       return;
     }
 
@@ -100,11 +103,11 @@ const AddLocationModal = ({
         }),
       );
 
-      toast.success("Location created successfully");
+      toast.success(t.orgLocationManagement.addModal.messages.success[lang]);
       resetForm();
       onClose();
     } catch (error) {
-      toast.error("Failed to create location");
+      toast.error(t.orgLocationManagement.addModal.messages.error[lang]);
       console.error("Error creating location:", error);
     } finally {
       setIsSubmitting(false);
@@ -134,9 +137,11 @@ const AddLocationModal = ({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Add New Location</DialogTitle>
+          <DialogTitle>
+            {t.orgLocationManagement.addModal.title[lang]}
+          </DialogTitle>
           <DialogDescription>
-            Create a new storage location for this organization
+            {t.orgLocationManagement.addModal.description[lang]}
           </DialogDescription>
         </DialogHeader>
 
@@ -145,7 +150,7 @@ const AddLocationModal = ({
             {/* Name */}
             <div className="space-y-2">
               <Label htmlFor="name" className="text-sm font-medium">
-                Location Name *
+                {t.orgLocationManagement.addModal.fields.name.label[lang]} *
               </Label>
               <Input
                 id="name"
@@ -153,7 +158,9 @@ const AddLocationModal = ({
                 onChange={(e) =>
                   setFormData((prev) => ({ ...prev, name: e.target.value }))
                 }
-                placeholder="Enter location name"
+                placeholder={
+                  t.orgLocationManagement.addModal.fields.name.placeholder[lang]
+                }
                 required
               />
             </div>
@@ -161,7 +168,7 @@ const AddLocationModal = ({
             {/* Image URL */}
             <div className="space-y-2">
               <Label htmlFor="image_url" className="text-sm font-medium">
-                Image URL
+                {t.orgLocationManagement.addModal.fields.imageUrl.label[lang]}
               </Label>
               <Input
                 id="image_url"
@@ -173,14 +180,20 @@ const AddLocationModal = ({
                     image_url: e.target.value,
                   }))
                 }
-                placeholder="https://example.com/image.jpg"
+                placeholder={
+                  t.orgLocationManagement.addModal.fields.imageUrl.placeholder[
+                    lang
+                  ]
+                }
               />
             </div>
           </div>
 
           {/* Address Fields */}
           <div className="space-y-4">
-            <Label className="text-sm font-medium">Address *</Label>
+            <Label className="text-sm font-medium">
+              {t.orgLocationManagement.addModal.labels.address[lang]} *
+            </Label>
 
             <div className="space-y-3">
               <div className="space-y-2">
@@ -188,7 +201,7 @@ const AddLocationModal = ({
                   htmlFor="street"
                   className="text-sm font-medium text-muted-foreground"
                 >
-                  Street Address
+                  {t.orgLocationManagement.addModal.fields.street.label[lang]}
                 </Label>
                 <Input
                   id="street"
@@ -196,7 +209,11 @@ const AddLocationModal = ({
                   onChange={(e) =>
                     setFormData((prev) => ({ ...prev, street: e.target.value }))
                   }
-                  placeholder="Enter street address"
+                  placeholder={
+                    t.orgLocationManagement.addModal.fields.street.placeholder[
+                      lang
+                    ]
+                  }
                   required
                 />
               </div>
@@ -207,7 +224,7 @@ const AddLocationModal = ({
                     htmlFor="city"
                     className="text-sm font-medium text-muted-foreground"
                   >
-                    City
+                    {t.orgLocationManagement.addModal.fields.city.label[lang]}
                   </Label>
                   <Input
                     id="city"
@@ -215,7 +232,11 @@ const AddLocationModal = ({
                     onChange={(e) =>
                       setFormData((prev) => ({ ...prev, city: e.target.value }))
                     }
-                    placeholder="Enter city"
+                    placeholder={
+                      t.orgLocationManagement.addModal.fields.city.placeholder[
+                        lang
+                      ]
+                    }
                     required
                   />
                 </div>
@@ -225,7 +246,11 @@ const AddLocationModal = ({
                     htmlFor="postcode"
                     className="text-sm font-medium text-muted-foreground"
                   >
-                    Postcode
+                    {
+                      t.orgLocationManagement.addModal.fields.postcode.label[
+                        lang
+                      ]
+                    }
                   </Label>
                   <Input
                     id="postcode"
@@ -236,7 +261,10 @@ const AddLocationModal = ({
                         postcode: e.target.value,
                       }))
                     }
-                    placeholder="Enter postcode"
+                    placeholder={
+                      t.orgLocationManagement.addModal.fields.postcode
+                        .placeholder[lang]
+                    }
                     required
                   />
                 </div>
@@ -247,7 +275,7 @@ const AddLocationModal = ({
           {/* Description */}
           <div className="space-y-2">
             <Label htmlFor="description" className="text-sm font-medium">
-              Description
+              {t.orgLocationManagement.addModal.fields.description.label[lang]}
             </Label>
             <Textarea
               id="description"
@@ -258,7 +286,11 @@ const AddLocationModal = ({
                   description: e.target.value,
                 }))
               }
-              placeholder="Enter location description..."
+              placeholder={
+                t.orgLocationManagement.addModal.fields.description.placeholder[
+                  lang
+                ]
+              }
               rows={3}
             />
           </div>
@@ -267,7 +299,7 @@ const AddLocationModal = ({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="latitude" className="text-sm font-medium">
-                Latitude
+                {t.orgLocationManagement.addModal.fields.latitude.label[lang]}
               </Label>
               <Input
                 id="latitude"
@@ -282,13 +314,17 @@ const AddLocationModal = ({
                       : undefined,
                   }))
                 }
-                placeholder="e.g. 60.1699"
+                placeholder={
+                  t.orgLocationManagement.addModal.fields.latitude.placeholder[
+                    lang
+                  ]
+                }
               />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="longitude" className="text-sm font-medium">
-                Longitude
+                {t.orgLocationManagement.addModal.fields.longitude.label[lang]}
               </Label>
               <Input
                 id="longitude"
@@ -303,7 +339,11 @@ const AddLocationModal = ({
                       : undefined,
                   }))
                 }
-                placeholder="e.g. 24.9384"
+                placeholder={
+                  t.orgLocationManagement.addModal.fields.longitude.placeholder[
+                    lang
+                  ]
+                }
               />
             </div>
           </div>
@@ -318,16 +358,18 @@ const AddLocationModal = ({
               }
             />
             <Label htmlFor="is_active" className="text-sm font-medium">
-              Active Location
+              {t.orgLocationManagement.addModal.fields.isActive.label[lang]}
             </Label>
           </div>
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={handleClose}>
-              Cancel
+              {t.orgLocationManagement.addModal.buttons.cancel[lang]}
             </Button>
             <Button type="submit" disabled={isSubmitting} variant={"secondary"}>
-              {isSubmitting ? "Creating..." : "Create Location"}
+              {isSubmitting
+                ? t.orgLocationManagement.addModal.buttons.creating[lang]
+                : t.orgLocationManagement.addModal.buttons.create[lang]}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/Admin/OrgManagement/DeleteLocationButton.tsx
+++ b/frontend/src/components/Admin/OrgManagement/DeleteLocationButton.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { toastConfirm } from "../../ui/toastConfirm";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
 
 interface DeleteLocationButtonProps {
   locationId: string;
@@ -20,20 +22,26 @@ const DeleteLocationButton = ({
   organizationId,
 }: DeleteLocationButtonProps) => {
   const dispatch = useAppDispatch();
+  const { lang } = useLanguage();
 
   const handleDelete = () => {
+    const locationInfo = t.orgLocationManagement.deleteModal.locationInfo[
+      lang
+    ].replace("{name}", locationName);
+    const description = `${locationInfo}\n\n${t.orgLocationManagement.deleteModal.description[lang]}`;
+
     toastConfirm({
-      title: "Remove Organization Location",
-      description: `Are you sure you want to remove "${locationName}" from this organization? The storage location data will be preserved in the system for potential future use.`,
-      confirmText: "Remove",
-      cancelText: "Cancel",
+      title: t.orgLocationManagement.deleteModal.title[lang],
+      description: description,
+      confirmText: t.orgLocationManagement.deleteModal.buttons.delete[lang],
+      cancelText: t.orgLocationManagement.deleteModal.buttons.cancel[lang],
       onConfirm: async () => {
         await toast.promise(
           dispatch(deleteOrgLocationWithStorage(locationId)).unwrap(),
           {
-            loading: "Removing location from organization...",
-            success: "Location removed from organization successfully",
-            error: "Failed to remove location",
+            loading: t.orgLocationManagement.deleteModal.messages.loading[lang],
+            success: t.orgLocationManagement.deleteModal.messages.success[lang],
+            error: t.orgLocationManagement.deleteModal.messages.error[lang],
           },
         );
 
@@ -52,7 +60,7 @@ const DeleteLocationButton = ({
   return (
     <Button variant="outline" size="sm" onClick={handleDelete}>
       <Trash2 className="h-3 w-3 mr-1" />
-      Delete
+      {t.orgLocationManagement.deleteModal.buttons.delete[lang]}
     </Button>
   );
 };

--- a/frontend/src/components/Admin/OrgManagement/EditLocationModal.tsx
+++ b/frontend/src/components/Admin/OrgManagement/EditLocationModal.tsx
@@ -22,6 +22,8 @@ import {
   UpdateOrgLocationWithStorage,
 } from "@/types/organizationLocation";
 import { toast } from "sonner";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
 
 interface EditLocationModalProps {
   location: OrgLocationWithNames | null;
@@ -93,6 +95,7 @@ const EditLocationModal = ({
   onClose,
 }: EditLocationModalProps) => {
   const dispatch = useAppDispatch();
+  const { lang } = useLanguage();
   const [formData, setFormData] = useState<FormData>({
     name: "",
     street: "",
@@ -193,10 +196,10 @@ const EditLocationModal = ({
         }),
       );
 
-      toast.success("Location updated successfully");
+      toast.success(t.orgLocationManagement.editModal.messages.success[lang]);
       onClose();
     } catch (error) {
-      toast.error("Failed to update location");
+      toast.error(t.orgLocationManagement.editModal.messages.error[lang]);
       console.error("Error updating location:", error);
     } finally {
       setIsSubmitting(false);
@@ -228,49 +231,72 @@ const EditLocationModal = ({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Edit Location</DialogTitle>
+          <DialogTitle>
+            {t.orgLocationManagement.editModal.title[lang]}
+          </DialogTitle>
           <DialogDescription>
-            Update the organization location settings
+            {t.orgLocationManagement.editModal.description[lang]}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <FormField
             id="name"
-            label="Location Name"
+            label={t.orgLocationManagement.addModal.fields.name.label[lang]}
             value={formData.name}
             onChange={updateField("name")}
-            placeholder="Enter location name"
+            placeholder={
+              t.orgLocationManagement.addModal.fields.name.placeholder[lang]
+            }
             required
           />
 
           {/* Address Fields */}
           <div className="space-y-4">
-            <Label className="text-sm font-medium">Address *</Label>
+            <Label className="text-sm font-medium">
+              {t.orgLocationManagement.addModal.labels.address[lang]} *
+            </Label>
             <div className="space-y-3">
               <FormField
                 id="street"
-                label="Street Address"
+                label={
+                  t.orgLocationManagement.addModal.fields.street.label[lang]
+                }
                 value={formData.street}
                 onChange={updateField("street")}
-                placeholder="Enter street address"
+                placeholder={
+                  t.orgLocationManagement.addModal.fields.street.placeholder[
+                    lang
+                  ]
+                }
                 required
               />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <FormField
                   id="city"
-                  label="City"
+                  label={
+                    t.orgLocationManagement.addModal.fields.city.label[lang]
+                  }
                   value={formData.city}
                   onChange={updateField("city")}
-                  placeholder="Enter city"
+                  placeholder={
+                    t.orgLocationManagement.addModal.fields.city.placeholder[
+                      lang
+                    ]
+                  }
                   required
                 />
                 <FormField
                   id="postcode"
-                  label="Postcode"
+                  label={
+                    t.orgLocationManagement.addModal.fields.postcode.label[lang]
+                  }
                   value={formData.postcode}
                   onChange={updateField("postcode")}
-                  placeholder="Enter postcode"
+                  placeholder={
+                    t.orgLocationManagement.addModal.fields.postcode
+                      .placeholder[lang]
+                  }
                   required
                 />
               </div>
@@ -279,10 +305,16 @@ const EditLocationModal = ({
 
           <FormField
             id="description"
-            label="Description"
+            label={
+              t.orgLocationManagement.addModal.fields.description.label[lang]
+            }
             value={formData.description}
             onChange={updateField("description")}
-            placeholder="Enter location description"
+            placeholder={
+              t.orgLocationManagement.addModal.fields.description.placeholder[
+                lang
+              ]
+            }
             rows={3}
           />
 
@@ -290,28 +322,42 @@ const EditLocationModal = ({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <FormField
               id="latitude"
-              label="Latitude"
+              label={
+                t.orgLocationManagement.addModal.fields.latitude.label[lang]
+              }
               value={formData.latitude}
               onChange={updateField("latitude")}
-              placeholder="Enter latitude"
+              placeholder={
+                t.orgLocationManagement.addModal.fields.latitude.placeholder[
+                  lang
+                ]
+              }
               type="number"
             />
             <FormField
               id="longitude"
-              label="Longitude"
+              label={
+                t.orgLocationManagement.addModal.fields.longitude.label[lang]
+              }
               value={formData.longitude}
               onChange={updateField("longitude")}
-              placeholder="Enter longitude"
+              placeholder={
+                t.orgLocationManagement.addModal.fields.longitude.placeholder[
+                  lang
+                ]
+              }
               type="number"
             />
           </div>
 
           <FormField
             id="image_url"
-            label="Image URL"
+            label={t.orgLocationManagement.addModal.fields.imageUrl.label[lang]}
             value={formData.image_url}
             onChange={updateField("image_url")}
-            placeholder="Enter image URL"
+            placeholder={
+              t.orgLocationManagement.addModal.fields.imageUrl.placeholder[lang]
+            }
           />
 
           {/* Active Status */}
@@ -324,16 +370,18 @@ const EditLocationModal = ({
               }
             />
             <Label htmlFor="is_active" className="text-sm font-medium">
-              Active Location
+              {t.orgLocationManagement.addModal.labels.activeLocation[lang]}
             </Label>
           </div>
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={handleClose}>
-              Cancel
+              {t.orgLocationManagement.editModal.buttons.cancel[lang]}
             </Button>
             <Button type="submit" disabled={isSubmitting} variant="secondary">
-              {isSubmitting ? "Updating..." : "Update Location"}
+              {isSubmitting
+                ? t.orgLocationManagement.editModal.buttons.saving[lang]
+                : t.orgLocationManagement.editModal.buttons.save[lang]}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/Admin/OrgManagement/OrgLocationManagement.tsx
+++ b/frontend/src/components/Admin/OrgManagement/OrgLocationManagement.tsx
@@ -13,6 +13,8 @@ import { OrgLocationWithNames } from "@/types/organizationLocation";
 import AddLocationModal from "./AddLocationModal";
 import EditLocationModal from "./EditLocationModal";
 import DeleteLocationButton from "./DeleteLocationButton";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
 
 interface OrgLocationManagementProps {
   organizationId: string;
@@ -25,6 +27,7 @@ const OrgLocationManagement = ({
   orgLocations,
   loading,
 }: OrgLocationManagementProps) => {
+  const { lang } = useLanguage();
   const [editingLocation, setEditingLocation] =
     useState<OrgLocationWithNames | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -46,12 +49,12 @@ const OrgLocationManagement = ({
       <div className="flex items-center justify-between">
         <div>
           <p className="text-muted-foreground">
-            Manage storage locations for this organization
+            {t.orgLocationManagement.header.description[lang]}
           </p>
         </div>
         <Button onClick={() => setIsCreateModalOpen(true)} variant="outline">
           <Plus className="h-4 w-4 mr-2" />
-          Add Location
+          {t.orgLocationManagement.header.addButton[lang]}
         </Button>
       </div>
 
@@ -97,24 +100,26 @@ const OrgLocationManagement = ({
                     </CardTitle>
                   </div>
                   <Badge variant={location.is_active ? "default" : "secondary"}>
-                    {location.is_active ? "Active" : "Inactive"}
+                    {location.is_active
+                      ? t.orgLocationManagement.status.active[lang]
+                      : t.orgLocationManagement.status.inactive[lang]}
                   </Badge>
                 </div>
                 <CardDescription className="text-xs">
-                  Address:{" "}
+                  {t.orgLocationManagement.locationCard.address[lang]}:{" "}
                   {location.storage_locations?.address ||
-                    "No address available"}
+                    t.orgLocationManagement.locationCard.noAddress[lang]}
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-2 text-xs text-muted-foreground">
                   <p>
-                    Organization:{" "}
+                    {t.orgLocationManagement.locationCard.organization[lang]}:{" "}
                     {location.organizations?.name || location.organization_id}
                   </p>
                   {location.created_at && (
                     <p>
-                      {"Created: "}
+                      {t.orgLocationManagement.locationCard.created[lang]}:{" "}
                       {new Date(location.created_at).toLocaleDateString()}
                     </p>
                   )}
@@ -126,7 +131,7 @@ const OrgLocationManagement = ({
                     onClick={() => openEditModal(location)}
                   >
                     <Edit className="h-3 w-3 mr-1" />
-                    Edit
+                    {t.orgLocationManagement.locationCard.editButton[lang]}
                   </Button>
 
                   <DeleteLocationButton
@@ -147,14 +152,14 @@ const OrgLocationManagement = ({
               <CardContent className="text-center py-12">
                 <MapPin className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                 <h3 className="text-lg font-semibold mb-2">
-                  No locations found
+                  {t.orgLocationManagement.emptyState.title[lang]}
                 </h3>
                 <p className="text-muted-foreground mb-4">
-                  This organization doesn't have any storage locations yet.
+                  {t.orgLocationManagement.emptyState.description[lang]}
                 </p>
                 <Button onClick={() => setIsCreateModalOpen(true)}>
                   <Plus className="h-4 w-4 mr-2" />
-                  Add First Location
+                  {t.orgLocationManagement.header.addFirstButton[lang]}
                 </Button>
               </CardContent>
             </Card>

--- a/frontend/src/pages/AdminPanel/OrganizationLocations.tsx
+++ b/frontend/src/pages/AdminPanel/OrganizationLocations.tsx
@@ -23,10 +23,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import OrgLocationManagement from "@/components/Admin/OrgManagement/OrgLocationManagement";
+import { useLanguage } from "@/context/LanguageContext";
+import { t } from "@/translations";
 
 const OrganizationLocations = () => {
   const dispatch = useAppDispatch();
   const { currentUserOrganizations } = useRoles();
+  const { lang } = useLanguage();
 
   // Redux state using selectors
   const orgLocations = useAppSelector(selectOrgLocations);
@@ -76,12 +79,13 @@ const OrganizationLocations = () => {
   if (!orgsWithLocationAccess || orgsWithLocationAccess.length === 0) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold">Organization Locations</h1>
+        <h1 className="text-2xl font-bold">
+          {t.orgLocationManagement.page.noAccess.title[lang]}
+        </h1>
         <Card>
           <CardContent className="pt-6">
             <p className="text-muted-foreground">
-              You don't have permission to manage locations in any organization.
-              Please contact your administrator.
+              {t.orgLocationManagement.page.noAccess.message[lang]}
             </p>
           </CardContent>
         </Card>
@@ -93,22 +97,28 @@ const OrganizationLocations = () => {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center space-x-3">
-        <h1 className="text-xl">Organization Locations</h1>
+        <h1 className="text-xl">{t.orgLocationManagement.page.title[lang]}</h1>
       </div>
 
       {/* Organization Selector (if user belongs to multiple orgs) */}
       {orgsWithLocationAccess.length > 1 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Select Organization</CardTitle>
+            <CardTitle className="text-lg">
+              {t.orgLocationManagement.page.selector.title[lang]}
+            </CardTitle>
             <CardDescription>
-              Choose which organization's locations you want to manage
+              {t.orgLocationManagement.page.selector.description[lang]}
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
               <SelectTrigger>
-                <SelectValue placeholder="Select an organization" />
+                <SelectValue
+                  placeholder={
+                    t.orgLocationManagement.page.selector.placeholder[lang]
+                  }
+                />
               </SelectTrigger>
               <SelectContent>
                 {orgsWithLocationAccess.map((org) => (
@@ -133,7 +143,12 @@ const OrganizationLocations = () => {
       {error && (
         <Card className="border-destructive">
           <CardContent className="pt-6">
-            <p className="text-destructive">Error loading locations: {error}</p>
+            <p className="text-destructive">
+              {t.orgLocationManagement.page.error[lang].replace(
+                "{error}",
+                error,
+              )}
+            </p>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/translations/index.ts
+++ b/frontend/src/translations/index.ts
@@ -44,6 +44,7 @@ import {
   organizationDelete,
   organizationList,
 } from "./modules/organizationsList";
+import { orgLocationManagement } from "./modules/orgLocationManagement";
 
 export const t = {
   addItemModal,
@@ -91,4 +92,5 @@ export const t = {
   currentUserRoles,
   organizationList,
   organizationDelete,
+  orgLocationManagement,
 };

--- a/frontend/src/translations/modules/adminPanel.ts
+++ b/frontend/src/translations/modules/adminPanel.ts
@@ -48,5 +48,9 @@ export const adminPanel = {
       fi: "Organisaatiot",
       en: "Organizations",
     },
+    locations: {
+      fi: "Sijainti",
+      en: "Locations",
+    },
   },
 };

--- a/frontend/src/translations/modules/orgLocationManagement.ts
+++ b/frontend/src/translations/modules/orgLocationManagement.ts
@@ -1,0 +1,341 @@
+export const orgLocationManagement = {
+  // OrganizationLocations Page
+  page: {
+    title: {
+      en: "Organization Locations",
+      fi: "Organisaation sijainnit",
+    },
+    noAccess: {
+      title: {
+        en: "Organization Locations",
+        fi: "Organisaation sijainnit",
+      },
+      message: {
+        en: "You don't have permission to manage locations in any organization. Please contact your administrator.",
+        fi: "Sinulla ei ole oikeuksia hallita sijainteja missään organisaatiossa. Ota yhteyttä järjestelmänvalvojaan.",
+      },
+    },
+    selector: {
+      title: {
+        en: "Select Organization",
+        fi: "Valitse organisaatio",
+      },
+      description: {
+        en: "Choose which organization's locations you want to manage",
+        fi: "Valitse, minkä organisaation sijainteja haluat hallita",
+      },
+      placeholder: {
+        en: "Select an organization",
+        fi: "Valitse organisaatio",
+      },
+    },
+    error: {
+      en: "Error loading locations: {error}",
+      fi: "Virhe sijaintien lataamisessa: {error}",
+    },
+  },
+
+  // OrgLocationManagement Component
+  header: {
+    description: {
+      en: "Manage storage locations for this organization",
+      fi: "Hallitse tämän organisaation varastosijainteja",
+    },
+    addButton: {
+      en: "Add Location",
+      fi: "Lisää sijainti",
+    },
+    addFirstButton: {
+      en: "Add First Location",
+      fi: "Lisää ensimmäinen sijainti",
+    },
+  },
+  locationCard: {
+    address: {
+      en: "Address",
+      fi: "Osoite",
+    },
+    organization: {
+      en: "Organization",
+      fi: "Organisaatio",
+    },
+    created: {
+      en: "Created",
+      fi: "Luotu",
+    },
+    editButton: {
+      en: "Edit",
+      fi: "Muokkaa",
+    },
+    deleteButton: {
+      en: "Delete",
+      fi: "Poista",
+    },
+    noAddress: {
+      en: "No address available",
+      fi: "Osoitetta ei ole saatavilla",
+    },
+  },
+  status: {
+    active: {
+      en: "Active",
+      fi: "Aktiivinen",
+    },
+    inactive: {
+      en: "Inactive",
+      fi: "Ei aktiivinen",
+    },
+  },
+  emptyState: {
+    title: {
+      en: "No locations found",
+      fi: "Sijainteja ei löytynyt",
+    },
+    description: {
+      en: "This organization doesn't have any storage locations yet.",
+      fi: "Tällä organisaatiolla ei ole vielä varastosijainteja.",
+    },
+  },
+
+  // AddLocationModal Component
+  addModal: {
+    title: {
+      en: "Add New Location",
+      fi: "Lisää uusi sijainti",
+    },
+    description: {
+      en: "Create a new storage location for this organization",
+      fi: "Luo uusi varastosijainti tälle organisaatiolle",
+    },
+    fields: {
+      name: {
+        label: {
+          en: "Location Name",
+          fi: "Sijainnin nimi",
+        },
+        placeholder: {
+          en: "Enter location name",
+          fi: "Syötä sijainnin nimi",
+        },
+      },
+      street: {
+        label: {
+          en: "Street Address",
+          fi: "Katuosoite",
+        },
+        placeholder: {
+          en: "Enter street address",
+          fi: "Syötä katuosoite",
+        },
+      },
+      city: {
+        label: {
+          en: "City",
+          fi: "Kaupunki",
+        },
+        placeholder: {
+          en: "Enter city",
+          fi: "Syötä kaupunki",
+        },
+      },
+      postcode: {
+        label: {
+          en: "Postal Code",
+          fi: "Postinumero",
+        },
+        placeholder: {
+          en: "Enter postal code",
+          fi: "Syötä postinumero",
+        },
+      },
+      description: {
+        label: {
+          en: "Description",
+          fi: "Kuvaus",
+        },
+        placeholder: {
+          en: "Enter location description",
+          fi: "Syötä sijainnin kuvaus",
+        },
+      },
+      latitude: {
+        label: {
+          en: "Latitude",
+          fi: "Leveysaste",
+        },
+        placeholder: {
+          en: "Enter latitude (optional)",
+          fi: "Syötä leveysaste (valinnainen)",
+        },
+      },
+      longitude: {
+        label: {
+          en: "Longitude",
+          fi: "Pituusaste",
+        },
+        placeholder: {
+          en: "Enter longitude (optional)",
+          fi: "Syötä pituusaste (valinnainen)",
+        },
+      },
+      imageUrl: {
+        label: {
+          en: "Image URL",
+          fi: "Kuvan URL",
+        },
+        placeholder: {
+          en: "Enter image URL (optional)",
+          fi: "Syötä kuvan URL (valinnainen)",
+        },
+      },
+      isActive: {
+        label: {
+          en: "Active Location",
+          fi: "Aktiivinen sijainti",
+        },
+        description: {
+          en: "Whether this location is currently active",
+          fi: "Onko tämä sijainti tällä hetkellä aktiivinen",
+        },
+      },
+    },
+    labels: {
+      address: {
+        en: "Address",
+        fi: "Osoite",
+      },
+      coordinates: {
+        en: "Coordinates",
+        fi: "Koordinaatit",
+      },
+      status: {
+        en: "Status",
+        fi: "Tila",
+      },
+      activeLocation: {
+        en: "Active Location",
+        fi: "Aktiivinen sijainti",
+      },
+    },
+    buttons: {
+      create: {
+        en: "Create Location",
+        fi: "Luo sijainti",
+      },
+      creating: {
+        en: "Creating...",
+        fi: "Luodaan...",
+      },
+      cancel: {
+        en: "Cancel",
+        fi: "Peruuta",
+      },
+    },
+    messages: {
+      success: {
+        en: "Location created successfully!",
+        fi: "Sijainti luotu onnistuneesti!",
+      },
+      error: {
+        en: "Failed to create location",
+        fi: "Sijainnin luominen epäonnistui",
+      },
+    },
+  },
+
+  // EditLocationModal Component
+  editModal: {
+    title: {
+      en: "Edit Location",
+      fi: "Muokkaa sijaintia",
+    },
+    description: {
+      en: "Update the details of this storage location",
+      fi: "Päivitä tämän varastosijainnin tiedot",
+    },
+    buttons: {
+      save: {
+        en: "Save Changes",
+        fi: "Tallenna muutokset",
+      },
+      saving: {
+        en: "Saving...",
+        fi: "Tallennetaan...",
+      },
+      cancel: {
+        en: "Cancel",
+        fi: "Peruuta",
+      },
+    },
+    messages: {
+      success: {
+        en: "Location updated successfully!",
+        fi: "Sijainti päivitetty onnistuneesti!",
+      },
+      error: {
+        en: "Failed to update location",
+        fi: "Sijainnin päivittäminen epäonnistui",
+      },
+    },
+  },
+
+  // DeleteLocationButton Component
+  deleteModal: {
+    title: {
+      en: "Delete Location",
+      fi: "Poista sijainti",
+    },
+    description: {
+      en: "Are you sure you want to delete this location? This action cannot be undone.",
+      fi: "Oletko varma, että haluat poistaa tämän sijainnin? Tätä toimintoa ei voi perua.",
+    },
+    locationInfo: {
+      en: "Location: {name}",
+      fi: "Sijainti: {name}",
+    },
+    buttons: {
+      delete: {
+        en: "Delete",
+        fi: "Poista",
+      },
+      deleting: {
+        en: "Deleting...",
+        fi: "Poistetaan...",
+      },
+      cancel: {
+        en: "Cancel",
+        fi: "Peruuta",
+      },
+    },
+    messages: {
+      loading: {
+        en: "Removing location from organization...",
+        fi: "Poistetaan sijaintia organisaatiosta...",
+      },
+      success: {
+        en: "Location deleted successfully!",
+        fi: "Sijainti poistettu onnistuneesti!",
+      },
+      error: {
+        en: "Failed to delete location",
+        fi: "Sijainnin poistaminen epäonnistui",
+      },
+    },
+  },
+
+  // Common validation messages
+  validation: {
+    required: {
+      en: "This field is required",
+      fi: "Tämä kenttä on pakollinen",
+    },
+    requiredFields: {
+      en: "Name, street, city, and postcode are required",
+      fi: "Nimi, katuosoite, kaupunki ja postinumero ovat pakollisia",
+    },
+    invalidNumber: {
+      en: "Please enter a valid number",
+      fi: "Syötä kelvollinen numero",
+    },
+  },
+};


### PR DESCRIPTION
Added translations to all Org Locations files and updated role-based access control in the Admin Panel regarding Organizations tab with the universal hasRole("super_admin") hook.

### Localization Enhancements:
* Replaced hardcoded strings in `AddLocationModal`, `DeleteLocationButton`, and `EditLocationModal` with dynamic translations using the `useLanguage` context and `t` function. Did the same in all the relevant parent components.

### Role-Based Access Control Updates:
* Replaced `isSuperAdmin` checks with `hasRole("super_admin")` for better granularity and consistency in role validation.
* Removed double, unused or commented-out role checks, such as `isSuperVera`, to clean up the code.