### PR TITLE
Fixed the frontend errors happening when the user logs in

### DIFF
--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -6,7 +6,7 @@ import { LoaderCircle } from "lucide-react";
 import { AuthContext } from "./AuthContext";
 import { useAppDispatch } from "@/store/hooks";
 import { resetRoles, fetchCurrentUserRoles } from "@/store/slices/rolesSlice";
-import { clearSelectedUser, getUserById } from "@/store/slices/usersSlice";
+import { clearSelectedUser, getCurrentUser } from "@/store/slices/usersSlice";
 import { AuthRedirect } from "@/components/Auth/AuthRedirect";
 import { getAuthToken, clearCachedAuthToken } from "@/api/axios";
 import { toast } from "sonner";
@@ -221,7 +221,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             .then(() => {
               setRolesLoaded(true);
               // After roles are loaded, fetch user profile data
-              void dispatch(getUserById(user.id));
+              void dispatch(getCurrentUser());
             })
             .catch((error) => {
               // If role loading fails, wait a bit and retry
@@ -231,12 +231,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               }
               setRolesLoaded(true);
               // Still try to load user profile even if roles failed
-              void dispatch(getUserById(user.id));
+              void dispatch(getCurrentUser());
             });
         } catch {
           setRolesLoaded(true);
           // Try to load profile even if token verification failed
-          void dispatch(getUserById(user.id));
+          void dispatch(getCurrentUser());
         }
       };
 


### PR DESCRIPTION
This pull request refactors how the current user's profile is fetched in the `AuthProvider` component. Instead of dispatching `getUserById` with the user's ID, it now dispatches the new `getCurrentUser` action, streamlining the process of retrieving the logged-in user's data.

**Refactor: User Profile Fetching**

* Replaced imports of `getUserById` with `getCurrentUser` in `AuthProvider.tsx` to simplify fetching the current user's profile.
* Updated all dispatch calls from `getUserById(user.id)` to `getCurrentUser()` within the `AuthProvider` logic, ensuring the current user's data is consistently loaded after authentication and role checks. [[1]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5L224-R224) [[2]](diffhunk://#diff-c5988b94ea3fc5586a8fdad872627efca79041edf7d4b4171e4e949086ee05c5L234-R239)