### PR TITLE
fix locations backend filter for Storage Items

### DIFF
--- a/backend/src/modules/storage-items/storage-items.controller.ts
+++ b/backend/src/modules/storage-items/storage-items.controller.ts
@@ -63,7 +63,7 @@ export class StorageItemsController {
     @Query("ascending") ascending: string = "true",
     @Query("tags") tags: string,
     @Query("active") active_filter: "active" | "inactive",
-    @Query("locations") location_filter: string,
+    @Query("location") location_filter: string,
     @Query("category") category: string,
     @Query("availability_min") availability_min?: string,
     @Query("availability_max") availability_max?: string,

--- a/backend/src/modules/storage-items/storage-items.service.ts
+++ b/backend/src/modules/storage-items/storage-items.service.ts
@@ -508,8 +508,15 @@ export class StorageItemsService {
 
     if (activity_filter) query.eq("is_active", activity_filter);
     if (tags) query.overlaps("tag_ids", tags.split(","));
-    if (location_filter)
-      query.overlaps("location_id", location_filter.split(","));
+    if (location_filter) {
+      const locIds = location_filter
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean);
+      if (locIds.length > 0) {
+        query.in("location_id", locIds);
+      }
+    }
 
     // Apply org-based item ID filter
     if (orgFilteredItemIds) query.in("id", orgFilteredItemIds);


### PR DESCRIPTION
Changed the backend filter from .overlaps("location_id", ...) to .in("location_id", ...) so it works with a string column.
Before we have the .overlaps operator which only works on array columns, so this threw an error and caused 500.