### PR TITLE
ensure itemSlice updates instantly on location and tags edit

### DIFF
--- a/frontend/src/components/Admin/Items/AssignTagsModal.tsx
+++ b/frontend/src/components/Admin/Items/AssignTagsModal.tsx
@@ -45,10 +45,13 @@ const AssignTagsModal: React.FC<AssignTagsModalProps> = ({
   const { lang } = useLanguage();
 
   useEffect(() => {
-    if (open && tags.length === 0) {
+    if (!open) return;
+    // Ensure full tag list exists
+    if (tags.length === 0) {
       void dispatch(fetchAllTags({ limit: 20 }));
-      void dispatch(fetchTagsForItem(itemId));
     }
+    // Always fetch the latest assigned tags for this item on open
+    void dispatch(fetchTagsForItem(itemId));
   }, [open, dispatch, itemId, tags.length]);
 
   useEffect(() => {
@@ -73,6 +76,9 @@ const AssignTagsModal: React.FC<AssignTagsModalProps> = ({
           tagIds: localSelectedTags,
         }),
       ).unwrap();
+
+      // Refresh selected tags from the server to keep subsequent opens in sync
+      await dispatch(fetchTagsForItem(itemId)).unwrap();
 
       const updatedTags = tags.filter((tag) =>
         localSelectedTags.includes(tag.id),

--- a/frontend/src/components/Admin/Items/UpdateItemModal.tsx
+++ b/frontend/src/components/Admin/Items/UpdateItemModal.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
 import {
   fetchAllTags,
+  fetchTagsForItem,
   selectAllTags,
   selectSelectedTags,
   selectTagsLoading,
@@ -77,6 +78,13 @@ const UpdateItemModal = ({
     if (!tags || tags.length === 0) void dispatch(fetchAllTags({ limit: 20 }));
     if (locations.length === 0) void dispatch(fetchAllLocations({ limit: 20 }));
   }, [dispatch, locations.length, formData.id, tags]);
+
+  // Always refresh assigned tags for this item when the modal opens or item changes
+  useEffect(() => {
+    if (initialData?.id) {
+      void dispatch(fetchTagsForItem(initialData.id));
+    }
+  }, [dispatch, initialData?.id]);
 
   useEffect(() => {
     if (selectedTags) {
@@ -174,6 +182,8 @@ const UpdateItemModal = ({
           data: { ...formData, tags: localSelectedTags },
         }),
       ).unwrap();
+      // Ensure tag slice reflects latest assignments for next open
+      await dispatch(fetchTagsForItem(formData.id));
       toast.success(t.updateItemModal.messages.success[lang]);
       onClose();
     } catch (error) {


### PR DESCRIPTION
This pull request improves how tag assignments for items are managed and synchronized in the admin UI. The main focus is ensuring that the latest tag data is always fetched and displayed when modals are opened or after tag updates, and that the Redux state is updated immutably to trigger UI updates.

**Tag assignment and synchronization improvements:**

* In both `AssignTagsModal.tsx` and `UpdateItemModal.tsx`, the code now always fetches the latest assigned tags for an item when the modal opens or after tags are updated, ensuring that users see up-to-date tag information. [[1]](diffhunk://#diff-864f413e0fdb31e0b0a0ef98981df76ba1f3f53525389912616b26d15b7fecf7L48-R54) [[2]](diffhunk://#diff-864f413e0fdb31e0b0a0ef98981df76ba1f3f53525389912616b26d15b7fecf7R80-R82) [[3]](diffhunk://#diff-1a95c3b3ebfa9869622b96f12c6f33389e399a61684dc720f1c844347f9d5497R82-R88) [[4]](diffhunk://#diff-1a95c3b3ebfa9869622b96f12c6f33389e399a61684dc720f1c844347f9d5497R185-R186)
* The Redux slice (`itemsSlice.ts`) now immutably updates the `items` array and `selectedItem` when tags are assigned, which ensures that UI components relying on referential equality (like tables) react to changes.

**General item update handling:**

* When an item is updated, the slice now shallow-merges the update payload with the existing item, preserving view-only fields that may not be included in the update response, and keeps the details view in sync if it's open.

**Supporting changes:**

* Added missing import for `fetchTagsForItem` in `UpdateItemModal.tsx` to support the new tag fetching behavior.