### PR TITLE
Con2 184 adapt roles guard attach active org id with request

### DIFF
--- a/backend/src/guards/roles.guard.ts
+++ b/backend/src/guards/roles.guard.ts
@@ -87,6 +87,13 @@ export class RolesGuard implements CanActivate {
 
     // Determine organisation context when sameOrg flag is set
     const orgCtx = sameOrg ? req.activeRoleContext?.organizationId : undefined;
+    const roleCtx = sameOrg ? req.activeRoleContext?.roleName : undefined;
+    // If sameOrg is required, but orgId or roleName is missing — forbid access
+    if (sameOrg && (!orgCtx || !roleCtx)) {
+      throw new ForbiddenException(
+        "Organization context or role is missing (check request headers (Postman) or activeRoleContextfrontend)",
+      );
+    }
 
     // Evaluate role matches
     const matches = userRoles.filter(

--- a/backend/src/guards/roles.guard.ts
+++ b/backend/src/guards/roles.guard.ts
@@ -91,7 +91,7 @@ export class RolesGuard implements CanActivate {
     // If sameOrg is required, but orgId or roleName is missing — forbid access
     if (sameOrg && (!orgCtx || !roleCtx)) {
       throw new ForbiddenException(
-        "Organization context or role is missing (check request headers (Postman) or activeRoleContextfrontend)",
+        "Organization context or role is missing (check request headers (Postman) or activeRoleContext (frontend)",
       );
     }
 

--- a/backend/src/guards/roles.guard.ts
+++ b/backend/src/guards/roles.guard.ts
@@ -86,9 +86,7 @@ export class RolesGuard implements CanActivate {
     }
 
     // Determine organisation context when sameOrg flag is set
-    const orgCtx =
-      sameOrg &&
-      (req.params?.organizationId ?? req.headers?.["x-org-id"] ?? null);
+    const orgCtx = sameOrg ? req.activeRoleContext?.organizationId : undefined;
 
     // Evaluate role matches
     const matches = userRoles.filter(

--- a/backend/src/guards/specs/roles.guard.spec.ts
+++ b/backend/src/guards/specs/roles.guard.spec.ts
@@ -23,14 +23,12 @@ function mockContext({
   isPublic = false,
   meta,
   userRoles = [],
-  orgParam,
-  orgHeader,
+  activeOrgId,
 }: {
   isPublic?: boolean;
   meta?: RolesMeta;
   userRoles?: FakeUserRole[];
-  orgParam?: string;
-  orgHeader?: string;
+  activeOrgId?: string;
 } = {}): ExecutionContext {
   const handler = () => {};
   if (isPublic) Reflect.defineMetadata(IS_PUBLIC_KEY, true, handler);
@@ -38,8 +36,9 @@ function mockContext({
 
   const req = {
     userRoles,
-    params: orgParam ? { organizationId: orgParam } : {},
-    headers: orgHeader ? { "x-org-id": orgHeader } : {},
+    activeRoleContext: activeOrgId
+      ? { organizationId: activeOrgId }
+      : undefined,
   };
 
   return {
@@ -100,14 +99,14 @@ describe("RolesGuard", () => {
     const ctx = mockContext({
       meta,
       userRoles: [{ role_name: "tenant_admin", organization_id: "org1" }],
-      orgParam: "org2", // mismatched org
+      activeOrgId: "org2", // mismatched org
     });
     expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
 
     const ctxMatch = mockContext({
       meta,
       userRoles: [{ role_name: "tenant_admin", organization_id: "org1" }],
-      orgParam: "org1",
+      activeOrgId: "org1",
     });
     expect(guard.canActivate(ctxMatch)).toBe(true);
   });

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -33,7 +33,13 @@ async function bootstrap() {
       origin: origins,
       credentials: true,
       methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Authorization", "x-user-id"],
+      allowedHeaders: [
+        "Content-Type",
+        "Authorization",
+        "x-user-id",
+        "x-org-id",
+        "x-role-name",
+      ],
     });
     app.getHttpAdapter().get("/health", async (req, res: Response) => {
       try {

--- a/backend/src/middleware/Auth.middleware.ts
+++ b/backend/src/middleware/Auth.middleware.ts
@@ -138,6 +138,14 @@ export class AuthMiddleware implements NestMiddleware {
       req.supabase = supabase;
       req.user = user;
       req.userRoles = userRoles;
+      // Extract x-org-id and x-role-name from headers (frontend activeContext) and attach them to the request object for downstream use.
+      req.activeRoleContext = {
+        organizationId: req.headers["x-org-id"] as string | undefined,
+        roleName: req.headers["x-role-name"] as string | undefined,
+      };
+      this.logger.debug(
+        `ActiveRoleContext: orgId=${req.activeRoleContext.organizationId}, roleName=${req.activeRoleContext.roleName}`,
+      );
 
       return next();
     } catch (err: unknown) {

--- a/backend/src/middleware/interfaces/auth-request.interface.ts
+++ b/backend/src/middleware/interfaces/auth-request.interface.ts
@@ -16,4 +16,8 @@ export interface AuthRequest extends Request {
   supabase: SupabaseClient<Database>;
   user: User;
   userRoles: ViewUserRolesWithDetails[];
+  activeRoleContext?: {
+    organizationId?: string;
+    roleName?: string;
+  };
 }

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -35,7 +35,10 @@ export class UserController {
 
   // Admin/tenant_admin and super roles: paginated, filtered; super roles see all orgs
   @Get("ordered")
-  @Roles(["tenant_admin", "super_admin", "superVera"], { match: "any" })
+  @Roles(["tenant_admin", "super_admin", "superVera"], {
+    match: "any",
+    sameOrg: true,
+  })
   async getAllOrderedUsers(
     @Req() req: AuthRequest,
     @Query() query: GetOrderedUsersDto,

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { supabase } from "../config/supabase";
 import { store } from "@/store/store";
 import { fetchCurrentUserRoles } from "@/store/slices/rolesSlice";
+import { selectActiveRoleContext } from "@/store/slices/rolesSlice";
 
 // Cache the token to avoid unnecessary async calls
 let cachedToken: string | null = null;
@@ -49,6 +50,16 @@ api.interceptors.request.use(async (config) => {
   const userId = localStorage.getItem("userId");
   if (userId) {
     config.headers["x-user-id"] = userId;
+  }
+
+  // Send orgId and  roleName from the activeRoleContext as custom headers on each api call
+  const state = store.getState();
+  const context = selectActiveRoleContext(state);
+  if (context.organizationId) {
+    config.headers["x-org-id"] = context.organizationId;
+  }
+  if (context.roleName) {
+    config.headers["x-role-name"] = context.roleName;
   }
 
   return config;

--- a/frontend/src/pages/AdminPanel/UsersList.tsx
+++ b/frontend/src/pages/AdminPanel/UsersList.tsx
@@ -84,15 +84,18 @@ const UsersList = () => {
   // 2. User has selected a super_admin or superVera role from the navbar selector
   const isActiveRoleSuper =
     activeRoleName === "super_admin" || activeRoleName === "superVera";
-  const shouldFetchAllUsers = isSuper && (!activeOrgId || isActiveRoleSuper);
 
   // Get the org_filter value based on super user logic
   const getOrgFilter = useCallback(() => {
-    if (shouldFetchAllUsers) {
+    // Super roles see all users if no org selected
+    if (isSuper) {
       return undefined; // No filter - fetch all users
     }
-    return activeOrgId ?? undefined; // Use selected org or undefined
-  }, [shouldFetchAllUsers, activeOrgId]);
+    // Tenant admin must always filter by their org
+    if (activeRoleName === "tenant_admin") {
+      return activeOrgId;
+    }
+  }, [isSuper, activeOrgId, activeRoleName]);
 
   // Get available roles for filtering - only show roles from current org context
   const availableRoles = useMemo(() => {
@@ -233,7 +236,7 @@ const UsersList = () => {
     if (!authLoading && isAuthorized && isModalOpen) {
       void dispatch(
         fetchAllOrderedUsers({
-          org_filter: getOrgFilter(),
+          org_filter: getOrgFilter() ?? undefined,
           page: 1,
           limit: 10,
           ascending: true,
@@ -527,7 +530,7 @@ const UsersList = () => {
         onPageChange={(page) =>
           dispatch(
             fetchAllOrderedUsers({
-              org_filter: getOrgFilter(),
+              org_filter: getOrgFilter() ?? undefined,
               page: page + 1,
               limit: 10,
               ascending: true,

--- a/frontend/src/pages/AdminPanel/UsersList.tsx
+++ b/frontend/src/pages/AdminPanel/UsersList.tsx
@@ -84,18 +84,15 @@ const UsersList = () => {
   // 2. User has selected a super_admin or superVera role from the navbar selector
   const isActiveRoleSuper =
     activeRoleName === "super_admin" || activeRoleName === "superVera";
+  const shouldFetchAllUsers = isSuper && (!activeOrgId || isActiveRoleSuper);
 
   // Get the org_filter value based on super user logic
   const getOrgFilter = useCallback(() => {
-    // Super roles see all users if no org selected
-    if (isSuper) {
+    if (shouldFetchAllUsers) {
       return undefined; // No filter - fetch all users
     }
-    // Tenant admin must always filter by their org
-    if (activeRoleName === "tenant_admin") {
-      return activeOrgId;
-    }
-  }, [isSuper, activeOrgId, activeRoleName]);
+    return activeOrgId ?? undefined; // Use selected org or undefined
+  }, [shouldFetchAllUsers, activeOrgId]);
 
   // Get available roles for filtering - only show roles from current org context
   const availableRoles = useMemo(() => {
@@ -236,7 +233,7 @@ const UsersList = () => {
     if (!authLoading && isAuthorized && isModalOpen) {
       void dispatch(
         fetchAllOrderedUsers({
-          org_filter: getOrgFilter() ?? undefined,
+          org_filter: getOrgFilter(),
           page: 1,
           limit: 10,
           ascending: true,
@@ -530,7 +527,7 @@ const UsersList = () => {
         onPageChange={(page) =>
           dispatch(
             fetchAllOrderedUsers({
-              org_filter: getOrgFilter() ?? undefined,
+              org_filter: getOrgFilter(),
               page: page + 1,
               limit: 10,
               ascending: true,


### PR DESCRIPTION
This pull request introduces a more robust organization and role context propagation between the frontend and backend, ensuring that API requests are correctly associated with the user's active organization and role. The main changes include passing `x-org-id` and `x-role-name` headers from the frontend, extracting these on the backend, updating guards and middleware to use the new context, and tightening authorization logic for user listing endpoints.

**Backend improvements for organization/role context:**

* The `AuthMiddleware` now extracts `x-org-id` and `x-role-name` from request headers and attaches them to the request as `activeRoleContext`, making this information available for downstream authorization checks. [[1]](diffhunk://#diff-3b75c2aa84b6e4cf0f86f5d4e8f3dd58444b6689527b88417807a6e7bc712a08R141-R148) [[2]](diffhunk://#diff-27cbb10c1b0e2d24f59d1862bfb8d1a876b629ed6097dd797925d32b02e5df43R19-R22)
* The `RolesGuard` uses `activeRoleContext` for organization and role checks when the `sameOrg` flag is set, and throws a `ForbiddenException` if either is missing.
* The CORS configuration in `main.ts` is updated to allow the new headers (`x-org-id`, `x-role-name`).

**Frontend propagation of active organization and role:**

* The Axios request interceptor sends `x-org-id` and `x-role-name` headers on every API request, sourced from the Redux store's `activeRoleContext`. [[1]](diffhunk://#diff-53f13e1b8e16a29e2bd3ae851f47cb967475a151bfef3fa6cfec57ab41e1cbcaR5) [[2]](diffhunk://#diff-53f13e1b8e16a29e2bd3ae851f47cb967475a151bfef3fa6cfec57ab41e1cbcaR55-R64)

**Authorization and user listing logic:**

* The `UserController`'s `getAllOrderedUsers` endpoint now requires both an appropriate role and matching organization context for access, enforcing stricter multi-tenancy.