### PR TITLE
Availability checking bugfix in ItemCard on /storage page

### DIFF
--- a/frontend/src/components/Items/ItemCard.tsx
+++ b/frontend/src/components/Items/ItemCard.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../store/slices/itemImagesSlice";
 import { Item } from "../../types/item";
 import { Input } from "../ui/input";
+import { itemsApi } from "@/api/services/items";
 
 interface ItemsCardProps {
   item: Item;
@@ -160,16 +161,30 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item }) => {
   };
 
   // Update availability info based on dates selection
-  // Since backend filtering already handles availability, no need for individual API calls
   useEffect(() => {
     if (startDate && endDate) {
-      // Backend filtering ensures only available items are shown
-      // Use the item's currently available quantity as the available quantity
-      setAvailabilityInfo({
-        availableQuantity: item.available_quantity || 0,
-        isChecking: false,
+      setAvailabilityInfo((prev) => ({
+        ...prev,
+        isChecking: true,
         error: null,
-      });
+      }));
+      void itemsApi
+        .checkAvailability(item.id, new Date(startDate), new Date(endDate))
+        .then((response) => {
+          setAvailabilityInfo({
+            availableQuantity: response.availableQuantity,
+            isChecking: false,
+            error: null,
+          });
+        })
+        .catch((error) => {
+          console.error("Error checking availability:", error);
+          setAvailabilityInfo({
+            availableQuantity: item.available_quantity || 0,
+            isChecking: false,
+            error: "Failed to check availability",
+          });
+        });
     } else {
       // When no dates selected, show total quantity
       setAvailabilityInfo({
@@ -178,7 +193,7 @@ const ItemCard: React.FC<ItemsCardProps> = ({ item }) => {
         error: null,
       });
     }
-  }, [startDate, endDate, item.available_quantity, item.quantity]);
+  }, [startDate, endDate, item.id, item.available_quantity, item.quantity]);
 
   const isItemAvailableForTimeframe = availabilityInfo.availableQuantity > 0;
 


### PR DESCRIPTION
**Availability checking improvements in ItemCard on /storage page:**

* Integrated `itemsApi.checkAvailability` to fetch up-to-date item availability from the backend when the user selects a start and end date, replacing the previous logic that relied on frontend filtering.
* Improved error handling for availability checks, displaying a fallback quantity and an error message if the API call fails.
* Updated the `useEffect` dependency array to include `item.id`, ensuring the effect runs when the item changes.