### PR TITLE
Con2 84 item id tag endpoint needs to be updated in the frontend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -36,7 +36,7 @@
         "supabase": "^2.31.8",
         "type-fest": "^4.41.0",
         "uuid": "^11.1.0",
-        "zod": "^4.0.15"
+        "zod": "^4.1.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -14443,9 +14443,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.15.tgz",
-      "integrity": "sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.4.tgz",
+      "integrity": "sha512-2YqJuWkU6IIK9qcE4k1lLLhyZ6zFw7XVRdQGpV97jEIZwTrscUw+DY31Xczd8nwaoksyJUIxCojZXwckJovWxA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,7 +51,7 @@
     "supabase": "^2.31.8",
     "type-fest": "^4.41.0",
     "uuid": "^11.1.0",
-    "zod": "^4.0.15"
+    "zod": "^4.1.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/modules/tag/tag.service.ts
+++ b/backend/src/modules/tag/tag.service.ts
@@ -30,14 +30,14 @@ export class TagService {
     // Get tags that are assigned to an item
     const { data: usageData, error: usageError } = await supabase
       .from("storage_item_tags")
-      .select("tag_id, count:tag_id", { count: "exact", head: false });
+      .select("tag_id");
 
     if (usageError) throw new Error(usageError.message);
 
-    // map for usage count
+    // Count occurrences manually
     const usageMap: Record<string, number> = {};
-    usageData?.forEach((u) => {
-      usageMap[u.tag_id] = Number(u.count);
+    usageData?.forEach((item) => {
+      usageMap[item.tag_id] = (usageMap[item.tag_id] || 0) + 1;
     });
 
     // base query for tags
@@ -86,7 +86,7 @@ export class TagService {
     // tags plus usageCount
     const tagsWithUsage = (result.data || []).map((tag: TagRow) => ({
       ...tag,
-      usageCount: usageMap[tag.id] ?? 0,
+      usageCount: usageMap[tag.id] || 0,
     }));
 
     return {

--- a/frontend/src/api/services/tags.ts
+++ b/frontend/src/api/services/tags.ts
@@ -1,4 +1,4 @@
-import { Tag, CreateTagDto, UpdateTagDto } from "@/types/tag";
+import { Tag, CreateTagDto, UpdateTagDto, TagWithUsage } from "@/types/tag";
 import { api } from "../axios";
 import { ApiResponse } from "@/types/api";
 
@@ -17,9 +17,9 @@ export const tagsApi = {
     assignmentFilter: string = "all",
     sortBy: string = "created_at",
     sortOrder: string = "desc",
-  ): Promise<ApiResponse<Tag[]>> => {
+  ): Promise<ApiResponse<TagWithUsage[]>> => {
     // Fetch paginated tags from the backend
-    const response: ApiResponse<Tag[]> = await api.get(
+    const response: ApiResponse<TagWithUsage[]> = await api.get(
       `/tags?page=${page}&limit=${limit}&search=${encodeURIComponent(search)}&assignmentFilter=${assignmentFilter}&sortBy=${sortBy}&sortOrder=${sortOrder}`,
     );
 

--- a/frontend/src/pages/AdminPanel/TagList.tsx
+++ b/frontend/src/pages/AdminPanel/TagList.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
-import { fetchAllItems, selectAllItems } from "@/store/slices/itemsSlice";
+// import { fetchAllItems, selectAllItems } from "@/store/slices/itemsSlice";
 import { useLanguage } from "@/context/LanguageContext";
 import { t } from "@/translations";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
@@ -33,7 +33,7 @@ import AddTagModal from "@/components/Admin/Items/AddTagModal";
 const TagList = () => {
   const dispatch = useAppDispatch();
   const tags = useAppSelector(selectAllTags);
-  const items = useAppSelector(selectAllItems);
+  // const items = useAppSelector(selectAllItems);
   const loading = useAppSelector(selectTagsLoading);
   const error = useAppSelector(selectError);
   const page = useAppSelector(selectTagsPage);
@@ -58,14 +58,6 @@ const TagList = () => {
   const [editTag, setEditTag] = useState<Tag | null>(null);
   const [editNameFi, setEditNameFi] = useState("");
   const [editNameEn, setEditNameEn] = useState("");
-
-  // Calculate tag usage for display
-  const tagUsage: Record<string, number> = {};
-  items.forEach((item) => {
-    (item.storage_item_tags || []).forEach((tag) => {
-      tagUsage[tag.id] = (tagUsage[tag.id] || 0) + 1;
-    });
-  });
 
   // Fetch tags when search term or assignment filter changes
   useEffect(() => {
@@ -99,11 +91,11 @@ const TagList = () => {
   }, [page]);
 
   // Fetch items once
-  useEffect(() => {
+  /*   useEffect(() => {
     if (items.length === 0) {
       void dispatch(fetchAllItems({ page: 1, limit: 10 }));
     }
-  }, [dispatch, items.length]);
+  }, [dispatch, items.length]); */
 
   const handlePageChange = (newPage: number) => {
     if (newPage < 1 || newPage > totalPages) return;
@@ -194,7 +186,7 @@ const TagList = () => {
       id: "assigned",
       cell: ({ row }) => {
         const tag = row.original;
-        const isUsed = !!tagUsage[tag.id];
+        const isUsed = tag.usageCount > 0; // need to put usage count to type!!!
         return isUsed ? (
           <span className="text-highlight2 font-medium">
             {t.tagList.assignment.yes[lang]}
@@ -210,9 +202,9 @@ const TagList = () => {
     {
       header: t.tagList.columns.assignedTo[lang],
       id: "assignedTo",
-      accessorFn: (row) => tagUsage[row.id] || 0,
+      accessorFn: (row) => row.usageCount,
       cell: ({ row }) => {
-        const count = tagUsage[row.original.id] || 0;
+        const count = row.original.usageCount;
         return (
           <span className="text-sm">
             {t.tagList.assignment.count[lang].replace(
@@ -224,6 +216,7 @@ const TagList = () => {
       },
       enableSorting: false,
     },
+
     {
       id: "actions",
       cell: ({ row }) => {

--- a/frontend/src/pages/AdminPanel/TagList.tsx
+++ b/frontend/src/pages/AdminPanel/TagList.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ColumnDef } from "@tanstack/react-table";
 import { Edit, LoaderCircle } from "lucide-react";
 import { PaginatedDataTable } from "@/components/ui/data-table-paginated";
-import { Tag, TagAssignmentFilter } from "@/types";
+import { Tag, TagAssignmentFilter, TagWithUsage } from "@/types";
 import {
   fetchFilteredTags,
   selectAllTags,
@@ -185,8 +185,8 @@ const TagList = () => {
       header: t.tagList.columns.assigned[lang],
       id: "assigned",
       cell: ({ row }) => {
-        const tag = row.original;
-        const isUsed = tag.usageCount > 0; // need to put usage count to type!!!
+        const tag = row.original as TagWithUsage;
+        const isUsed = tag.usageCount > 0;
         return isUsed ? (
           <span className="text-highlight2 font-medium">
             {t.tagList.assignment.yes[lang]}
@@ -202,9 +202,9 @@ const TagList = () => {
     {
       header: t.tagList.columns.assignedTo[lang],
       id: "assignedTo",
-      accessorFn: (row) => row.usageCount,
+      accessorFn: (row) => (row as TagWithUsage).usageCount ?? 0,
       cell: ({ row }) => {
-        const count = row.original.usageCount;
+        const count = (row.original as TagWithUsage).usageCount ?? 0;
         return (
           <span className="text-sm">
             {t.tagList.assignment.count[lang].replace(
@@ -216,7 +216,6 @@ const TagList = () => {
       },
       enableSorting: false,
     },
-
     {
       id: "actions",
       cell: ({ row }) => {

--- a/frontend/src/store/slices/tagSlice.ts
+++ b/frontend/src/store/slices/tagSlice.ts
@@ -260,7 +260,10 @@ export const tagSlice = createSlice({
       })
       .addCase(createTag.fulfilled, (state, action) => {
         state.loading = false;
-        state.tags.push(action.payload);
+        state.tags.push({
+          ...action.payload,
+          usageCount: 0,
+        });
       })
       .addCase(createTag.rejected, (state, action) => {
         state.loading = false;
@@ -273,9 +276,11 @@ export const tagSlice = createSlice({
         state.errorContext = null;
       })
       .addCase(updateTag.fulfilled, (state, action) => {
-        state.tags = state.tags.map((tag) =>
-          tag.id === action.payload.id ? action.payload : tag,
-        );
+        if (state.selectedTags) {
+          state.selectedTags = state.selectedTags.map((tag) =>
+            tag.id === action.payload.id ? action.payload : tag,
+          );
+        }
         state.loading = false;
       })
       .addCase(updateTag.rejected, (state, action) => {

--- a/frontend/src/types/tag.ts
+++ b/frontend/src/types/tag.ts
@@ -1,5 +1,7 @@
 import { ErrorContext } from "./common";
+import { Override } from "./db-helpers";
 import { Database, TagTranslations } from "./manualOverride";
+import { Tag as BaseTag } from "./tag";
 
 /** Runtime row shape for the `tags` table with typed `translations`. */
 export type Tag = Database["public"]["Tables"]["tags"]["Row"];
@@ -21,7 +23,7 @@ export type TagTranslation = TagTranslations["en"];
  * with loading/error flags and pagination metadata.
  */
 export interface TagState {
-  tags: Tag[];
+  tags: TagWithUsage[];
   loading: boolean;
   error: string | null;
   errorContext: ErrorContext;
@@ -42,3 +44,10 @@ export type ItemFormTag = { tag_id: string; translations: TagTranslations };
 
 /** UI filter values for tag‑assignment status. */
 export type TagAssignmentFilter = "all" | "assigned" | "unassigned";
+
+/** Extra field for counting usage */
+interface TagAugmentedFields {
+  usageCount: number;
+}
+/** Final row type */
+export type TagWithUsage = Override<BaseTag, TagAugmentedFields>;


### PR DESCRIPTION
This pull request updates how tag usage counts are handled and displayed throughout the backend and frontend. The main change is that the backend now calculates and returns a `usageCount` for each tag, which is then used by the frontend for display and filtering, eliminating the need for the frontend to compute usage itself. Additionally, the codebase is updated to use the new `TagWithUsage` type everywhere tags are handled, and the `zod` dependency is updated.

**Backend changes:**

* The backend `TagService` now returns tags with a `usageCount` field, calculated from the number of assignments in `storage_item_tags`. This enables assignment filtering and usage count display directly from the backend response.

* The `zod` package is updated from version `4.0.15` to `4.1.4` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L54-R54) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL39-R39) [[3]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL14446-R14448)

**Frontend changes:**

_Tag usage handling:_

* The frontend now uses the new `TagWithUsage` type everywhere tags are handled, updating API calls, Redux state, and UI components to expect and display the `usageCount` field. [[1]](diffhunk://#diff-033bdcd2566a2372a8f2640db3f339aae2a46dc62eaf0d615dfd874936bc322fL1-R1) [[2]](diffhunk://#diff-033bdcd2566a2372a8f2640db3f339aae2a46dc62eaf0d615dfd874936bc322fL20-R22) [[3]](diffhunk://#diff-cbdbe4bea390af358f4a122d69b5910242e5932440134b3566b34fb32be5bee6L24-R26) [[4]](diffhunk://#diff-cbdbe4bea390af358f4a122d69b5910242e5932440134b3566b34fb32be5bee6R47-R53)
* The previous logic to calculate tag usage on the frontend is removed; usage counts are now taken directly from the backend response. [[1]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L62-L69) [[2]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L196-R189) [[3]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L213-R207)

_Codebase cleanup:_

* Unused imports and references to item fetching for tag usage calculation are commented out or removed, reflecting the shift to backend-driven usage counts. [[1]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L26-R26) [[2]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L36-R36) [[3]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L102-R98)

_State management:_

* When creating a new tag, the Redux state now initializes its `usageCount` to zero. Updates to tags also respect the new type. [[1]](diffhunk://#diff-c1d88f1f4f82993fe14b03d27d17c9ec28af06dcbe33ac96bfc9a5eed2608e86L263-R266) [[2]](diffhunk://#diff-c1d88f1f4f82993fe14b03d27d17c9ec28af06dcbe33ac96bfc9a5eed2608e86L276-R283)

(Type references: [[1]](diffhunk://#diff-530ba3d5edbd71b6765c684c29eae9c6882b2ce6ddc963ddbfbc62d4dafe9d75L27-R93) [[2]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L54-R54) [[3]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL39-R39) [[4]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL14446-R14448) [[5]](diffhunk://#diff-033bdcd2566a2372a8f2640db3f339aae2a46dc62eaf0d615dfd874936bc322fL1-R1) [[6]](diffhunk://#diff-033bdcd2566a2372a8f2640db3f339aae2a46dc62eaf0d615dfd874936bc322fL20-R22) [[7]](diffhunk://#diff-cbdbe4bea390af358f4a122d69b5910242e5932440134b3566b34fb32be5bee6L24-R26) [[8]](diffhunk://#diff-cbdbe4bea390af358f4a122d69b5910242e5932440134b3566b34fb32be5bee6R47-R53) [[9]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L62-L69) [[10]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L196-R189) [[11]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L213-R207) [[12]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L26-R26) [[13]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L36-R36) [[14]](diffhunk://#diff-8e6f2ccb483c828b2f93bee47f3303c5cefda85bee500a40c6c6ec6d39a690a2L102-R98) [[15]](diffhunk://#diff-c1d88f1f4f82993fe14b03d27d17c9ec28af06dcbe33ac96bfc9a5eed2608e86L263-R266) [[16]](diffhunk://#diff-c1d88f1f4f82993fe14b03d27d17c9ec28af06dcbe33ac96bfc9a5eed2608e86L276-R283)