### PR TITLE
add new endpoint to get light list of all users  @Get(ordered-list)

### DIFF
--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -39,6 +39,25 @@ export class UserController {
   }
 
   /**
+   * Get a list of users with only name and email.
+   * Accessible by tenant admins and super admins.
+   * @param req - Authenticated request object
+   * @param query - Query parameters for pagination and filtering
+   * @returns List of users with name and email
+   */
+  @Get("ordered-list")
+  @Roles(["super_admin", "tenant_admin"], {
+    match: "any",
+    sameOrg: true,
+  })
+  async getAllOrderedUsersList(
+    @Req() req: AuthRequest,
+    @Query() query: GetOrderedUsersDto,
+  ) {
+    return this.userService.getAllOrderedUsersList(req, query);
+  }
+
+  /**
    * Get all users (paginated and filtered).
    * Accessible by super admins and tenant admins (within their organization).
    * @param req - Authenticated request object


### PR DESCRIPTION
This pull request introduces a new endpoint for retrieving a simplified, paginated, and ordered list of users, showing only their names and emails. This feature is restricted to tenant admins and super admins, and includes support for searching, ordering, and pagination.

**New endpoint for ordered user listing:**

* Added the `getAllOrderedUsersList` method to `UserController`, exposing a new `GET /ordered-list` endpoint for tenant and super admins to fetch users with only name and email fields.

**Service logic for user list retrieval:**

* Implemented the `getAllOrderedUsersList` method in `UserService`, which:
  - Queries the `user_profiles` table for `id`, `full_name`, and `email`.
  - Supports searching by email or name, ordering by a specified column, and paginating results.
  - Returns the user data and pagination metadata.