### PR TITLE
return list of org bookings for all admins

### DIFF
--- a/backend/src/modules/booking/booking.controller.ts
+++ b/backend/src/modules/booking/booking.controller.ts
@@ -29,7 +29,7 @@ export class BookingController {
 
   /**
    * Get ordered bookings with optional filters.
-   * Publicly accessible.
+   * Accessible by all admins within their organization.
    * @param req - Request object
    * @param searchquery - Search query for filtering bookings
    * @param ordered_by - Column to order by (default: created_at)
@@ -41,7 +41,7 @@ export class BookingController {
    * @returns Paginated and filtered list of bookings
    */
   @Get("ordered")
-  @Roles(["storage_manager", "tenant_admin"], {
+  @Roles(["requester", "storage_manager", "tenant_admin"], {
     match: "any",
     sameOrg: true,
   })
@@ -77,14 +77,14 @@ export class BookingController {
 
   /**
    * Get bookings of the current authenticated user.
-   * Accessible by users and requesters within their organization.
+   * Accessible by users and all admins within their organization.
    * @param req - Authenticated request object
    * @param page - Page number for pagination (default: 1)
    * @param limit - Number of items per page (default: 10)
    * @returns Paginated list of the user's bookings
    */
   @Get("my")
-  @Roles(["user", "requester"], {
+  @Roles(["user", "requester", "storage_manager", "tenant_admin"], {
     match: "any",
     sameOrg: true,
   })

--- a/backend/src/modules/booking/booking.service.ts
+++ b/backend/src/modules/booking/booking.service.ts
@@ -199,8 +199,12 @@ export class BookingService {
       return { ...result, metadata: pagination };
     }
 
-    // Restrict Requester to bookings for their organization
-    if (activeRole === "requester") {
+    // Restrict admins to bookings for their organization
+    if (
+      activeRole === "requester" ||
+      activeRole === "storage_manager" ||
+      activeRole === "tenant_admin"
+    ) {
       // Requesters can only see bookings for their organization
       if (!activeOrgId) {
         throw new ForbiddenException(

--- a/frontend/src/components/MyBookings.tsx
+++ b/frontend/src/components/MyBookings.tsx
@@ -169,7 +169,7 @@ const MyBookings = () => {
     }
 
     const { roleName } = activeContext;
-    if (roleName !== "user" && roleName !== "requester") {
+    if (roleName === "super_admin" || roleName === null) {
       return;
     }
 
@@ -552,8 +552,7 @@ const MyBookings = () => {
         </div>
 
         {/* BookingPreview table or empty state */}
-        {activeContext.roleName !== "user" &&
-        activeContext.roleName !== "requester" ? (
+        {activeContext.roleName === "super_admin" ? (
           <div className="text-center py-8 bg-slate-50 rounded-lg">
             <p className="text-lg mb-2">
               {t.myBookings.error.insufficientRole[lang]}

--- a/frontend/src/translations/modules/myBookings.ts
+++ b/frontend/src/translations/modules/myBookings.ts
@@ -13,16 +13,16 @@ export const myBookings = {
       en: "Please log in to view your bookings",
     },
     invalidContext: {
-      fi: "Virheellinen konteksti. Yritä uudelleen myöhemmin.",
-      en: "Invalid context. Please try again later.",
+      fi: "Virheellinen konteksti. Yritä uudelleen myöhemmin",
+      en: "Invalid context. Please try again later",
     },
     insufficientRole: {
       en: "You do not have permission to view bookings",
       fi: "Sinulla ei ole oikeuksia nähdä varauksia",
     },
     insufficientRoleDescription: {
-      en: "Only users and requesters can view bookings.",
-      fi: "Vain käyttäjät ja pyytäjät voivat tarkastella varauksia.",
+      en: "Choose another role to view bookings",
+      fi: "Valitse toinen rooli nähdäksesi varaukset",
     },
   },
   buttons: {


### PR DESCRIPTION
This pull request updates booking access control to allow all admin roles (including `storage_manager` and `tenant_admin`) to view bookings within their organization, and refines frontend role checks and messaging to match these changes. The most important changes are grouped below.

**Backend Access Control Updates:**

* The `BookingController` endpoints now allow `requester`, `storage_manager`, and `tenant_admin` roles to access ordered bookings, ensuring all admins within an organization have access. [[1]](diffhunk://#diff-bae9dbb27af68c78ceb7e81bfd3f0f8632982686bbf5358b919d24fe7cc47814L32-R32) [[2]](diffhunk://#diff-bae9dbb27af68c78ceb7e81bfd3f0f8632982686bbf5358b919d24fe7cc47814L44-R44)
* The "my bookings" endpoint is now accessible to all admin roles (`user`, `requester`, `storage_manager`, `tenant_admin`) within their organization, not just users and requesters.
* The `BookingService` restricts all admin roles to viewing bookings only for their organization, rather than just requesters.

**Frontend Role and Messaging Adjustments:**

* The `MyBookings` component now only restricts `super_admin` and null roles from viewing bookings, aligning with backend permissions.
* The empty state message for insufficient role is now shown only to `super_admin`, and not to other admin roles.
* The translation for insufficient role description has been updated to instruct users to choose another role to view bookings, reflecting the expanded access for admin roles.