### PR TITLE
Potential fix for code scanning alert no. 10: Type confusion through parameter tampering

### DIFF
--- a/backend/src/modules/item-images/item-images.service.ts
+++ b/backend/src/modules/item-images/item-images.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, BadRequestException } from "@nestjs/common";
 import { SupabaseService } from "../supabase/supabase.service";
 import { v4 as uuidv4 } from "uuid";
 import { AuthRequest } from "src/middleware/interfaces/auth-request.interface";
@@ -112,6 +112,19 @@ export class ItemImagesService {
     files: Express.Multer.File[],
     path?: string,
   ): Promise<BucketUploadResult> {
+    // Runtime type validation against type confusion through parameter tampering
+    if (
+      !Array.isArray(files) ||
+      files.some(
+        (file) =>
+          typeof file !== "object" ||
+          !file ||
+          typeof file.originalname !== "string" ||
+          typeof file.buffer === "undefined"
+      )
+    ) {
+      throw new BadRequestException("Invalid files parameter: expected array of files.");
+    }
     const supabase = req.supabase;
     const result: BucketUploadResult = {
       paths: [],


### PR DESCRIPTION
Potential fix for [https://github.com/con2/FullStack_Storage_and_Booking_App/security/code-scanning/10](https://github.com/con2/FullStack_Storage_and_Booking_App/security/code-scanning/10)

To fix the issue, the function `uploadToBucket` should validate the runtime type of the `files` argument before using it as an array. Specifically, check that `files` is an array of objects conforming to the expected file structure (`Express.Multer.File`). If not, throw a `BadRequestException` with a descriptive error. This check should be performed before attempting iteration or access to array properties.

Make the following changes:
- At the start of the `uploadToBucket` function in `backend/src/modules/item-images/item-images.service.ts`, add runtime type-check logic:
  - If `files` is not an array, or if any element is not an object (or missing required file properties, optionally), throw a BadRequestException.
- This may require importing `BadRequestException` from `@nestjs/common` in the service file if not already present.

Only code shown in this file should be modified; do not alter controller code or add custom helper classes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
