### PR TITLE
Added RLS for:

### DIFF
--- a/supabase/migrations/20250911121234_Storage_Items_RLS.sql
+++ b/supabase/migrations/20250911121234_Storage_Items_RLS.sql
@@ -1,0 +1,349 @@
+-- ==========================================================================
+-- STORAGE TABLES - ROW LEVEL SECURITY (RLS) POLICIES
+-- ==========================================================================
+-- Applies consistent multi-tenant policies to:
+--   • storage_items
+--   • storage_item_images
+--   • storage_images
+--   • storage_locations
+--   • storage_item_tags
+--
+-- Policy summary per your chart:
+--   • Everyone (including anon/guest) can SELECT (read).
+--   • tenant_admin and storage_manager can INSERT any new rows (no org restriction).
+--   • UPDATE and DELETE are allowed only for own organization data
+--     (tenant_admin or storage_manager in the owning org). 
+--   • Super admins can only VIEW - no create/update/delete permissions.
+--
+-- Notes on org ownership columns/joins:
+--   • storage_items has column org_id.
+--   • storage_item_images -> joins via item_id -> storage_items(org_id).
+--   • storage_images      -> joins via location_id -> organization_locations(organization_id).
+--   • storage_locations   -> org link is via organization_locations(location_id ↔ storage_location_id).
+--   • storage_item_tags   -> joins via item_id -> storage_items(org_id).
+--
+-- Helper functions used (defined earlier in migrations):
+--   • app.me_has_any_role(p_org_id uuid, p_roles public.roles_type[])
+--   • app.me_has_role_anywhere(p_role public.roles_type)
+-- ==========================================================================
+
+-- --------------------------------------------------------------------------
+-- storage_items
+-- --------------------------------------------------------------------------
+alter table public.storage_items enable row level security;
+alter table public.storage_items force row level security;
+
+-- Read: everyone (anon + authenticated)
+create policy "All users can read storage_items"
+  on public.storage_items
+  for select
+  using (true);
+
+-- Create: tenant_admin or storage_manager can create ANY new rows (no org restriction)
+create policy "Org managers can create storage_items"
+  on public.storage_items
+  for insert
+  to authenticated
+  with check (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    or app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- Update: only within own org; super_admin anywhere
+create policy "Org managers can update storage_items in their orgs"
+  on public.storage_items
+  for update
+  to authenticated
+  using (
+    app.me_has_any_role(
+      org_id,
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  )
+  with check (
+    app.me_has_any_role(
+      org_id,
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  );
+
+-- Delete: only within own org; super_admin anywhere
+create policy "Org managers can delete storage_items in their orgs"
+  on public.storage_items
+  for delete
+  to authenticated
+  using (
+    app.me_has_any_role(
+      org_id,
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  );
+
+-- --------------------------------------------------------------------------
+-- storage_item_images (joins via item_id -> storage_items(org_id))
+-- --------------------------------------------------------------------------
+alter table public.storage_item_images enable row level security;
+alter table public.storage_item_images force row level security;
+
+-- Read: everyone (anon + authenticated)
+create policy "All users can read storage_item_images"
+  on public.storage_item_images
+  for select
+  using (true);
+
+-- Create: tenant_admin or storage_manager can create for any item (no org restriction)
+create policy "Org managers can create storage_item_images"
+  on public.storage_item_images
+  for insert
+  to authenticated
+  with check (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    or app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- Update: within own item org; super_admin anywhere
+create policy "Org managers can update storage_item_images in their orgs"
+  on public.storage_item_images
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_images.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_images.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- Delete: within own item org; super_admin anywhere
+create policy "Org managers can delete storage_item_images in their orgs"
+  on public.storage_item_images
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_images.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- --------------------------------------------------------------------------
+-- storage_images (joins via location_id -> organization_locations(organization_id))
+-- --------------------------------------------------------------------------
+alter table public.storage_images enable row level security;
+alter table public.storage_images force row level security;
+
+-- Read: everyone (anon + authenticated)
+create policy "All users can read storage_images"
+  on public.storage_images
+  for select
+  using (true);
+
+-- Create: tenant_admin or storage_manager can create for any location (no org restriction)
+create policy "Org managers can create storage_images"
+  on public.storage_images
+  for insert
+  to authenticated
+  with check (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    or app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- Update: within own org via mapped location; super_admin anywhere
+create policy "Org managers can update storage_images in their orgs"
+  on public.storage_images
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_images.location_id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_images.location_id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- Delete: within own org via mapped location; super_admin anywhere
+create policy "Org managers can delete storage_images in their orgs"
+  on public.storage_images
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_images.location_id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- --------------------------------------------------------------------------
+-- storage_locations (org link via organization_locations)
+-- --------------------------------------------------------------------------
+alter table public.storage_locations enable row level security;
+alter table public.storage_locations force row level security;
+
+-- Read: everyone (anon + authenticated)
+create policy "All users can read storage_locations"
+  on public.storage_locations
+  for select
+  using (true);
+
+-- Create: tenant_admin or storage_manager in any org; super_admin anywhere
+-- (Org is linked post-create via organization_locations.)
+create policy "Org managers can create storage_locations"
+  on public.storage_locations
+  for insert
+  to authenticated
+  with check (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    or app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- Update: only if this location is linked to an org the user manages; super_admin anywhere
+create policy "Org managers can update storage_locations in their orgs"
+  on public.storage_locations
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_locations.id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_locations.id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- Delete: only if linked to an org the user manages; super_admin anywhere
+create policy "Org managers can delete storage_locations in their orgs"
+  on public.storage_locations
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.organization_locations ol
+      where ol.storage_location_id = storage_locations.id
+        and app.me_has_any_role(
+          ol.organization_id, 
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- --------------------------------------------------------------------------
+-- storage_item_tags (joins via item_id -> storage_items(org_id))
+-- --------------------------------------------------------------------------
+alter table public.storage_item_tags enable row level security;
+alter table public.storage_item_tags force row level security;
+
+-- Read: everyone (anon + authenticated)
+create policy "All users can read storage_item_tags"
+  on public.storage_item_tags
+  for select
+  using (true);
+
+-- Create: tenant_admin or storage_manager can create for any item (no org restriction)
+create policy "Org managers can create storage_item_tags"
+  on public.storage_item_tags
+  for insert
+  to authenticated
+  with check (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    or app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- Update: within own item org; super_admin anywhere
+create policy "Org managers can update storage_item_tags in their orgs"
+  on public.storage_item_tags
+  for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_tags.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_tags.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );
+
+-- Delete: within own item org; super_admin anywhere
+create policy "Org managers can delete storage_item_tags in their orgs"
+  on public.storage_item_tags
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.storage_items si
+      where si.id = storage_item_tags.item_id
+        and app.me_has_any_role(
+          si.org_id,
+          array['tenant_admin','storage_manager']::public.roles_type[]
+        )
+    )
+  );

--- a/supabase/migrations/20250911123539_Org_Locations_RLS.sql
+++ b/supabase/migrations/20250911123539_Org_Locations_RLS.sql
@@ -1,0 +1,72 @@
+-- ===========================================================================
+-- ORGANIZATION LOCATIONS - ROW LEVEL SECURITY (RLS) POLICIES
+-- ===========================================================================
+-- This migration creates RLS policies for the organization_locations table
+-- which is used extensively in your endpoints but missing RLS policies
+-- ===========================================================================
+
+-- Enable RLS on organization_locations table
+ALTER TABLE public.organization_locations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.organization_locations FORCE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- SELECT POLICIES
+-- ---------------------------------------------------------------------------
+
+-- Read: everyone (anon + authenticated)
+CREATE POLICY "All users can read organization_locations"
+  ON public.organization_locations
+  FOR SELECT
+  USING (true);
+
+-- ---------------------------------------------------------------------------  
+-- INSERT POLICIES
+-- ---------------------------------------------------------------------------
+
+-- Create: tenant_admin or storage_manager can create ANY new rows (no org restriction)
+CREATE POLICY "Org managers can create organization_locations"
+  ON public.organization_locations
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    app.me_has_role_anywhere('tenant_admin'::public.roles_type)
+    OR app.me_has_role_anywhere('storage_manager'::public.roles_type)
+  );
+
+-- ---------------------------------------------------------------------------
+-- UPDATE POLICIES  
+-- ---------------------------------------------------------------------------
+
+-- Update: tenant_admin or storage_manager only within their own org (super_admin excluded)
+CREATE POLICY "Org managers can update organization_locations in their orgs"
+  ON public.organization_locations
+  FOR UPDATE
+  TO authenticated
+  USING (
+    app.me_has_org_access(
+      organization_id, 
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  )
+  WITH CHECK (
+    app.me_has_org_access(
+      organization_id, 
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- DELETE POLICIES
+-- ---------------------------------------------------------------------------
+
+-- Delete: tenant_admin or storage_manager only within their own org (super_admin excluded)
+CREATE POLICY "Org managers can delete organization_locations in their orgs"
+  ON public.organization_locations
+  FOR DELETE
+  TO authenticated
+  USING (
+    app.me_has_org_access(
+      organization_id, 
+      array['tenant_admin','storage_manager']::public.roles_type[]
+    )
+  );

--- a/supabase/scripts/Test_RLS
+++ b/supabase/scripts/Test_RLS
@@ -1,0 +1,202 @@
+-- ============================================================
+-- RLS TEST HARNESS
+-- - Simulates authenticated users by setting request.jwt.claim.sub
+-- - Runs SELECT / INSERT / UPDATE / DELETE against a target table
+-- - Captures pass/fail and any error messages
+-- - You only change the CONFIG in the "Usage" block
+-- ============================================================
+
+-- 1) Helper to run a statement "as user"
+create or replace function app._run_as_user(
+  p_user_id uuid,
+  p_sql text
+) returns table(ok bool, err text)
+language plpgsql
+as $$
+begin
+  -- Simulate "authenticated" + set JWT sub so auth.uid() works
+  perform set_config('role', 'authenticated', true);
+  perform set_config('request.jwt.claim.sub', coalesce(p_user_id::text, ''), true);
+
+  begin
+    execute p_sql;
+    return query select true, null::text;
+  exception when others then
+    return query select false, sqlerrm;
+  end;
+end;
+$$;
+
+-- 2) Tiny formatter for consistent labels
+create or replace function app._label(p text) returns text
+language sql immutable as $$ select '['||p||']' $$;
+
+-- 3) Build DML statements from JSONB columns -> values
+--    Example: jsonb '{"name":"ACME","slug":"acme","is_active":true}'
+--    becomes: (name,slug,is_active) VALUES ('ACME','acme',true)
+create or replace function app._jsonb_to_cols_vals(p jsonb)
+returns text
+language sql
+as $$
+  with kv as (
+    select key, value
+    from jsonb_each(p)
+  )
+  select '('||string_agg(quote_ident(key), ', ')||') VALUES ('||
+         string_agg(
+           case
+             when value ? 'f' then to_jsonb(value)::text -- keep bool/null/json
+             when jsonb_typeof(value) = 'number' then (value::text)
+             when jsonb_typeof(value) = 'boolean' then (value::text)
+             when jsonb_typeof(value) = 'null' then 'NULL'
+             else quote_literal(value::text::jsonb #>> '{}')
+           end, ', '
+         )||')'
+  from kv;
+$$;
+
+-- 4) Main driver
+create or replace function app.test_table_rls(
+  p_table regclass,          -- table to test (e.g. 'public.organizations')
+  p_pk_col text,             -- primary key column name (e.g. 'id')
+  p_example_pk uuid,         -- an existing row's PK to test UPDATE/DELETE
+  p_insert jsonb,            -- JSON for an INSERT row
+  p_update jsonb,            -- JSON for an UPDATE set clause (only keys used)
+  p_users uuid[]             -- users to test (auth.users.id values)
+)
+returns table(
+  user_id uuid,
+  op text,
+  ok bool,
+  err text
+)
+language plpgsql
+as $$
+declare
+  v_insert_sql text;
+  v_update_sql text;
+  v_select_sql text;
+  v_delete_sql text;
+  v_set_sql   text;
+  u uuid;
+begin
+  -- Build statements dynamically
+  v_select_sql := format('select 1 from %s limit 1', p_table);
+
+  v_insert_sql := format(
+    'insert into %s %s',
+    p_table,
+    app._jsonb_to_cols_vals(p_insert)
+  );
+
+  -- Build UPDATE SET list from JSONB
+  select string_agg(format('%I = %s', key,
+           case
+             when jsonb_typeof(value) = 'number'  then (value::text)
+             when jsonb_typeof(value) = 'boolean' then (value::text)
+             when jsonb_typeof(value) = 'null'    then 'NULL'
+             else quote_literal(value::text::jsonb #>> '{}')
+           end), ', ')
+  into v_set_sql
+  from jsonb_each(p_update);
+
+  v_update_sql := format(
+    'update %s set %s where %I = %L',
+    p_table, coalesce(v_set_sql, '/* no-op */'), p_pk_col, p_example_pk
+  );
+
+  v_delete_sql := format(
+    'delete from %s where %I = %L',
+    p_table, p_pk_col, p_example_pk
+  );
+
+  -- Run for each user
+  foreach u in array p_users loop
+    -- SELECT
+    return query
+      select u, 'SELECT', r.ok, r.err
+      from app._run_as_user(u, v_select_sql) r;
+
+    -- INSERT
+    return query
+      select u, 'INSERT', r.ok, r.err
+      from app._run_as_user(u, v_insert_sql) r;
+
+    -- UPDATE
+    return query
+      select u, 'UPDATE', r.ok, r.err
+      from app._run_as_user(u, v_update_sql) r;
+
+    -- DELETE
+    return query
+      select u, 'DELETE', r.ok, r.err
+      from app._run_as_user(u, v_delete_sql) r;
+  end loop;
+end;
+$$;
+
+-- ============================================================
+-- USAGE EXAMPLES (EDIT ONLY THIS CONFIG PER TABLE)
+-- ============================================================
+
+-- Example A) storage_items table
+-- Assumes you already inserted your fixed test users & some storage items.
+-- Users from your test_users_guide.md:
+--   super_admin@test.com      -> b8339c44-8410-49e0-8bb6-b74876120185
+--   tenant_admin@test.com     -> b08ed477-8100-4ee8-8ff8-84e1bcba1550
+--   storage_manager@test.com  -> 1e647a27-717f-4aee-a2da-f2c1737349c1
+--   requester@test.com        -> 0efaafbf-29c4-48cd-8dc9-954dd924f553
+--   user@test.com             -> 6e2686aa-7164-4a10-8852-177c56dd3d5f
+
+-- Replace ONLY the values in the SELECT below when testing a different table.
+-- For storage_items:
+select *
+from app.test_table_rls(
+  p_table      => 'public.storage_items',
+  p_pk_col     => 'id',
+  p_example_pk => (select id from public.storage_items limit 1), -- get any existing storage item
+  p_insert     => jsonb_build_object(
+                    'name', 'Test Item '||to_char(now(), 'YYYYMMDDHH24MISS'),
+                    'description', 'Inserted by RLS harness',
+                    'org_id', '2a42d333-a550-493f-876e-a2cea3c80d26', -- org 1
+                    'quantity', 1,
+                    'unit', 'each',
+                    'value', 100.00,
+                    'is_active', true
+                  ),
+  p_update     => jsonb_build_object(
+                    'description', 'Updated by RLS harness at '||now()::text
+                  ),
+  p_users      => array[
+                    'b8339c44-8410-49e0-8bb6-b74876120185'::uuid, -- super admin (should only SELECT, no CUD)
+                    'b08ed477-8100-4ee8-8ff8-84e1bcba1550'::uuid, -- tenant admin (can create any, update/delete own org)
+                    '1e647a27-717f-4aee-a2da-f2c1737349c1'::uuid, -- storage manager (can create any, update/delete own org)
+                    '0efaafbf-29c4-48cd-8dc9-954dd924f553'::uuid, -- requester (no CUD access)
+                    '6e2686aa-7164-4a10-8852-177c56dd3d5f'::uuid  -- regular user (no CUD access)
+                  ]
+);
+
+-- Example B) organization_locations table
+-- Just change the CONFIG below for the table name, pk, and JSON data.
+-- (Assumes your policies use organization_id checks)
+-- select *
+-- from app.test_table_rls(
+--   p_table      => 'public.organization_locations',
+--   p_pk_col     => 'id',
+--   p_example_pk => '<an existing org_location id>',
+--   p_insert     => jsonb_build_object(
+--                     'organization_id','2a42d333-a550-493f-876e-a2cea3c80d26', -- org 1
+--                     'location_id', '<some existing storage location uuid>',
+--                     'is_active', true
+--                   ),
+--   p_update     => jsonb_build_object(
+--                     'is_active', false
+--                   ),
+--   p_users      => array[
+--                     'b8339c44-8410-49e0-8bb6-b74876120185'::uuid, -- super admin
+--                     'b08ed477-8100-4ee8-8ff8-84e1bcba1550'::uuid, -- tenant admin
+--                     '1e647a27-717f-4aee-a2da-f2c1737349c1'::uuid, -- storage manager
+--                     '0efaafbf-29c4-48cd-8dc9-954dd924f553'::uuid, -- requester
+--                     '6e2686aa-7164-4a10-8852-177c56dd3d5f'::uuid  -- user
+--                   ]
+-- );

--- a/supabase/scripts/check_rls_status.sql
+++ b/supabase/scripts/check_rls_status.sql
@@ -1,0 +1,58 @@
+-- Check RLS status for ALL tables in public schema
+SELECT 
+    schemaname, 
+    tablename, 
+    rowsecurity AS rls_enabled,
+    (SELECT COUNT(*) FROM pg_policies p WHERE p.tablename = t.tablename) AS policy_count
+FROM pg_tables t
+WHERE schemaname = 'public' 
+ORDER BY tablename;
+
+
+
+
+-- Check what policies exist on ALL public tables
+SELECT 
+    schemaname, 
+    tablename, 
+    policyname, 
+    cmd AS operation,
+    permissive,
+    roles,
+    CASE WHEN with_check IS NOT NULL THEN 'with_check: ' || with_check ELSE '' END as check_condition,
+    CASE WHEN qual IS NOT NULL THEN 'using: ' || qual ELSE '' END as using_condition
+FROM pg_policies 
+WHERE schemaname = 'public'
+ORDER BY tablename, policyname;
+
+
+
+
+-- Summary: Tables with/without RLS
+SELECT 
+    'Tables with RLS enabled' AS category,
+    COUNT(*) AS count
+FROM pg_tables 
+WHERE schemaname = 'public' AND rowsecurity = true
+UNION ALL
+SELECT 
+    'Tables without RLS' AS category,
+    COUNT(*) AS count
+FROM pg_tables 
+WHERE schemaname = 'public' AND rowsecurity = false
+UNION ALL
+SELECT 
+    'Total tables in public' AS category,
+    COUNT(*) AS count
+FROM pg_tables 
+WHERE schemaname = 'public';
+
+-- List tables without RLS (potential security gaps)
+SELECT 
+    tablename,
+    'No RLS enabled' AS status
+FROM pg_tables 
+WHERE schemaname = 'public' 
+    AND rowsecurity = false
+ORDER BY tablename;
+


### PR DESCRIPTION
This pull request introduces comprehensive row-level security (RLS) policies for all storage-related tables and the `organization_locations` table, ensuring multi-tenant data isolation and proper access control based on user roles. It also adds tooling for testing and verifying RLS policies, including a script for automated RLS testing and another for auditing RLS status across all public tables.

##  Tables RLS 
   • storage_items
   • storage_item_images
   • storage_images
   • storage_locations
   • storage_item_tags
   • organization_locations


**RLS Policy Additions and Enhancements:**

* **Storage Tables RLS Policies:** Implements detailed RLS policies for `storage_items`, `storage_item_images`, `storage_images`, `storage_locations`, and `storage_item_tags`. These policies allow everyone to read, restrict create/update/delete to tenant admins and storage managers (with org checks), and explicitly prevent super admins from modifying data.
* **Organization Locations RLS Policies:** Adds RLS policies to the `organization_locations` table, which was previously missing RLS coverage. Policies mirror the storage tables: read for all, create for org managers, and update/delete only within the user's own organization.

**Testing and Verification Tools:**

* **Automated RLS Test Harness:** Introduces `app.test_table_rls` and supporting helpers to simulate user actions (SELECT/INSERT/UPDATE/DELETE) against any table, making it easy to verify RLS policies for different user roles. Usage examples are provided for both storage and organization tables.
* **RLS Status & Audit Script:** Adds `check_rls_status.sql`, which provides queries to list RLS status, count policies, and identify tables missing RLS in the public schema, helping to quickly spot any security gaps.