### PR TITLE
Updated supabase to have 1 client constantly

### DIFF
--- a/frontend/src/config/supabase.ts
+++ b/frontend/src/config/supabase.ts
@@ -11,21 +11,14 @@ console.log("Supabase configuration check:", {
   mode: import.meta.env.MODE,
 });
 
-// Check if we're on a password reset URL before creating the Supabase client
-const isPasswordResetFlow = () => {
-  return (
-    window.location.href.includes("type=recovery") ||
-    window.location.hash.includes("type=recovery") ||
-    window.location.pathname.includes("/password-reset")
-  );
-};
-
-// Create Supabase client with graceful fallback
+// Always create a stable Supabase client.
+// Password reset flow is handled within the PasswordReset component
+// and should not change global auth client behavior.
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    autoRefreshToken: !isPasswordResetFlow(),
-    persistSession: !isPasswordResetFlow(),
-    detectSessionInUrl: !isPasswordResetFlow(),
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: true,
   },
 });
 


### PR DESCRIPTION
This pull request simplifies the Supabase client initialization logic in `frontend/src/config/supabase.ts` by always enabling session persistence and token refresh, regardless of the password reset flow. The logic for handling password reset scenarios is now delegated to the relevant component, resulting in a more stable and predictable global authentication client setup.

## Supabase Changes
In supabase I required a more complex password and tested the password reset with the new system to make sure there are no bugs

Supabase client initialization:

* Removed the `isPasswordResetFlow` function and its conditional logic, so the Supabase client is always created with `autoRefreshToken`, `persistSession`, and `detectSessionInUrl` set to `true`.
* Added comments clarifying that password reset handling is now managed within the `PasswordReset` component, not in the global config.