### PR TITLE
Con2 258 bookings rls

### DIFF
--- a/supabase/migrations/20250915081311_Bookings-RLS.sql
+++ b/supabase/migrations/20250915081311_Bookings-RLS.sql
@@ -1,0 +1,190 @@
+-- ==========================================================================
+-- BOOKINGS + BOOKING_ITEMS - ROW LEVEL SECURITY (RLS) POLICIES
+-- ==========================================================================
+-- Based on the policy chart:
+--   • Super Admin and Guests (anon) have NO access to any booking data.
+--   • Tenant Admin, Storage Manager, Requester, User (approved) can
+--     - bookings: READ/CREATE/UPDATE/DELETE, but only their own data.
+--       Own data means either:
+--         • they are the booking owner (bookings.user_id = auth.uid()), or
+--         • they hold an allowed role in a provider org linked via booking_items
+--           (tenant_admin, storage_manager, requester).
+--     - booking_items: Tenant Admin can INSERT/UPDATE/DELETE within their org;
+--       everyone above may READ items limited to own data:
+--         • items for bookings they own OR
+--         • items where they have the allowed role in provider_organization_id.
+--
+-- Helper functions used (see earlier migrations):
+--   • app.me_is_super_admin()
+--   • app.me_has_role(p_org_id uuid, p_role public.roles_type)
+--   • app.me_has_any_role(p_org_id uuid, p_roles public.roles_type[])
+-- ==========================================================================
+
+-- --------------------------------------------------------------------------
+-- BOOKINGS
+-- --------------------------------------------------------------------------
+alter table public.bookings enable row level security;
+alter table public.bookings force row level security;
+
+-- Block anonymous access entirely
+create policy "Anonymous users cannot access bookings"
+  on public.bookings
+  for all
+  to anon
+  using (false);
+
+-- READ: booking owner OR member of provider org on any of its items; super_admin excluded
+create policy "Members can read own or org bookings"
+  on public.bookings
+  for select
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and (
+      user_id = auth.uid()
+      or exists (
+        select 1
+        from public.booking_items bi
+        where bi.booking_id = bookings.id
+          and app.me_has_any_role(
+            bi.provider_organization_id,
+            array['tenant_admin','storage_manager','requester']::public.roles_type[]
+          )
+      )
+    )
+  );
+
+-- CREATE: only as the booking owner; super_admin excluded
+create policy "Users can create their own bookings"
+  on public.bookings
+  for insert
+  to authenticated
+  with check (
+    not app.me_is_super_admin()
+    and user_id = auth.uid()
+  );
+
+-- UPDATE: same scope as READ; super_admin excluded
+create policy "Members can update own or org bookings"
+  on public.bookings
+  for update
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and (
+      user_id = auth.uid()
+      or exists (
+        select 1
+        from public.booking_items bi
+        where bi.booking_id = bookings.id
+          and app.me_has_any_role(
+            bi.provider_organization_id,
+            array['tenant_admin','storage_manager','requester']::public.roles_type[]
+          )
+      )
+    )
+  )
+  with check (
+    not app.me_is_super_admin()
+    and (
+      user_id = auth.uid()
+      or exists (
+        select 1
+        from public.booking_items bi
+        where bi.booking_id = bookings.id
+          and app.me_has_any_role(
+            bi.provider_organization_id,
+            array['tenant_admin','storage_manager','requester']::public.roles_type[]
+          )
+      )
+    )
+  );
+
+-- DELETE: same scope as READ; super_admin excluded
+create policy "Members can delete own or org bookings"
+  on public.bookings
+  for delete
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and (
+      user_id = auth.uid()
+      or exists (
+        select 1
+        from public.booking_items bi
+        where bi.booking_id = bookings.id
+          and app.me_has_any_role(
+            bi.provider_organization_id,
+            array['tenant_admin','storage_manager','requester']::public.roles_type[]
+          )
+      )
+    )
+  );
+
+-- --------------------------------------------------------------------------
+-- BOOKING_ITEMS
+-- --------------------------------------------------------------------------
+alter table public.booking_items enable row level security;
+alter table public.booking_items force row level security;
+
+-- Block anonymous access entirely
+create policy "Anonymous users cannot access booking_items"
+  on public.booking_items
+  for all
+  to anon
+  using (false);
+
+-- READ: items for own bookings OR items from provider orgs where member has allowed roles; super_admin excluded
+create policy "Members can read booking_items for own bookings or provider orgs"
+  on public.booking_items
+  for select
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and (
+      exists (
+        select 1
+        from public.bookings b
+        where b.id = booking_items.booking_id
+          and b.user_id = auth.uid()
+      )
+      or app.me_has_any_role(
+        booking_items.provider_organization_id,
+        array['tenant_admin','storage_manager','requester']::public.roles_type[]
+      )
+    )
+  );
+
+-- INSERT: only tenant_admin for the provider org; super_admin excluded
+create policy "Tenant admins can insert booking_items in their orgs"
+  on public.booking_items
+  for insert
+  to authenticated
+  with check (
+    not app.me_is_super_admin()
+    and app.me_has_role(provider_organization_id, 'tenant_admin'::public.roles_type)
+  );
+
+-- UPDATE: only tenant_admin for the provider org; super_admin excluded
+create policy "Tenant admins can update booking_items in their orgs"
+  on public.booking_items
+  for update
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and app.me_has_role(provider_organization_id, 'tenant_admin'::public.roles_type)
+  )
+  with check (
+    not app.me_is_super_admin()
+    and app.me_has_role(provider_organization_id, 'tenant_admin'::public.roles_type)
+  );
+
+-- DELETE: only tenant_admin for the provider org; super_admin excluded
+create policy "Tenant admins can delete booking_items in their orgs"
+  on public.booking_items
+  for delete
+  to authenticated
+  using (
+    not app.me_is_super_admin()
+    and app.me_has_role(provider_organization_id, 'tenant_admin'::public.roles_type)
+  );


### PR DESCRIPTION
This pull request introduces comprehensive Row Level Security (RLS) policies for the `bookings` and `booking_items` tables to ensure that only authorized users can access or modify booking data. The changes enforce strict access controls based on user roles and booking ownership, blocking anonymous and super admin access, and allowing only authenticated users with specific roles to interact with their own data or data linked to their organization.

**RLS Policy Enforcement:**

* Enabled and forced RLS on both `public.bookings` and `public.booking_items` tables to ensure all access is governed by defined policies.

**Access Restrictions:**

* Completely blocked anonymous users and super admins from accessing any booking or booking item data by creating explicit policies for both tables.

**Bookings Table Policies:**

* Allowed authenticated users to read, create, update, and delete only their own bookings, ensuring that users can interact only with data where they are the booking owner.

**Booking Items Table Policies:**

* Permitted authenticated users to read booking items either for their own bookings or for provider organizations where they hold approved roles (`tenant_admin`, `storage_manager`, `requester`).
* Allowed insert, update, and delete operations on booking items only for booking owners or users with the `tenant_admin` role in the relevant provider organization. (F318b9ba