### PR TITLE
fix calendar: Week starts on monday and user can change months

### DIFF
--- a/frontend/src/components/InlineTimeframeSelector.tsx
+++ b/frontend/src/components/InlineTimeframeSelector.tsx
@@ -96,7 +96,7 @@ export default function InlineTimeframePicker({
                     ).getTime();
                 return isBeforeMin || isBeforeStart || isTooFar;
               }}
-              month={startDate ?? undefined}
+              defaultMonth={startDate ?? undefined}
             />
           </PopoverContent>
         </Popover>

--- a/frontend/src/components/InlineTimeframeSelector.tsx
+++ b/frontend/src/components/InlineTimeframeSelector.tsx
@@ -44,6 +44,7 @@ export default function InlineTimeframePicker({
             className="z-[60] w-auto p-0"
           >
             <Calendar
+              weekStartsOn={1}
               mode="single"
               selected={startDate ?? undefined}
               onSelect={(date) => {
@@ -77,6 +78,7 @@ export default function InlineTimeframePicker({
             className="z-[60] w-auto p-0"
           >
             <Calendar
+              weekStartsOn={1}
               mode="single"
               selected={endDate ?? undefined}
               onSelect={(date) => {

--- a/frontend/src/components/TimeframeSelector.tsx
+++ b/frontend/src/components/TimeframeSelector.tsx
@@ -103,6 +103,7 @@ const TimeframeSelector: React.FC = () => {
               </PopoverTrigger>
               <PopoverContent className="w-auto max-w-xs p-0 break-words">
                 <Calendar
+                  weekStartsOn={1}
                   mode="single"
                   selected={startDate || undefined}
                   onSelect={(date) => handleDateChange("start", date)}
@@ -133,11 +134,12 @@ const TimeframeSelector: React.FC = () => {
               </PopoverTrigger>
               <PopoverContent className="w-auto max-w-xs p-0 break-words">
                 <Calendar
+                  weekStartsOn={1}
                   mode="single"
                   selected={endDate || undefined}
                   onSelect={(date) => handleDateChange("end", date)}
                   initialFocus
-                  month={startDate}
+                  defaultMonth={startDate} // Problem: Currently does not let user change month
                   disabled={(date) => {
                     // Always return a boolean value:
                     const isBeforeToday =
@@ -148,8 +150,9 @@ const TimeframeSelector: React.FC = () => {
                     // prevent dates more than 14 days from start
                     const isTooFarFromStart = startDate
                       ? date.getTime() >
-                        new Date(startDate.getTime() + 14 * 86400000).getTime()
+                        new Date(startDate.getTime() + 35 * 86400000).getTime()
                       : false;
+
                     return (
                       isBeforeToday || isBeforeStartDate || isTooFarFromStart
                     );


### PR DESCRIPTION
Calendar small bug fixes:
- User can now change months for the end date when picking dates
- Default month is still whatever month they chose for the start date
- Start of the week is now monday