### PR TITLE
Con2 362 add a see all to categories in the filtering options

### DIFF
--- a/frontend/src/components/Items/UserPanel.tsx
+++ b/frontend/src/components/Items/UserPanel.tsx
@@ -198,7 +198,7 @@ const UserPanel = () => {
             </div>
             <Separator className="my-4" />
 
-            {/* Categories / item_types*/}
+            {/* Categories/ item_types*/}
             <div className="flex flex-col flex-wrap gap-3">
               <label className="text-primary text-md block mb-0">
                 {" "}


### PR DESCRIPTION
This pull request enhances the category filter functionality in the `UserPanel` component by adding expand/collapse support, similar to other filter groups. The main changes introduce a shared expand/collapse state for categories, limit the number of visible categories by default, and add a toggle button for users to view all or fewer categories. :arrow_down: 

**Category filter improvements:**

* Added `"categories"` to the `ExpandableSection` type and the `expanded` state object, enabling expand/collapse behavior for the categories filter group.
* Limited the number of visible categories to five by default using the shared `getVisible` function, and displayed only the visible categories in the filter list. [[1]](diffhunk://#diff-ed107f91510ccf254f564a8a1b2522cd9fbcf493bcaa1d0c31896d43ea92829eL55-R78) [[2]](diffhunk://#diff-ed107f91510ccf254f564a8a1b2522cd9fbcf493bcaa1d0c31896d43ea92829eL200-R207)
* Added a "See all" / "Show less" toggle button below the category filter list, allowing users to expand or collapse the full list of categories.